### PR TITLE
build: verify CPM.cmake download against its SHA256 hash

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -15,9 +15,12 @@ endif()
 
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
+# EXPECTED_HASH verifies integrity and also skips the download entirely when
+# the file is already present and matches (offline reconfigures keep working).
 file(DOWNLOAD
     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
     ${CPM_DOWNLOAD_LOCATION}
+    EXPECTED_HASH SHA256=${CPM_HASH_SUM}
 )
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -120,6 +120,10 @@ void Game::run() {
         int steps = clock_.advance(frame_delta);
         for (int i = 0; i < steps; ++i) {
             fixed_update(Clock::TICK_RATE);
+            // Consume press edges after the first tick so one press fires
+            // exactly one tick. Unconsumed edges (frames that run zero
+            // ticks, e.g. on >120 Hz displays) stay latched in Input.
+            input_.consume_pressed();
         }
 
         // Render
@@ -150,11 +154,16 @@ void Game::render() {
 }
 
 void Game::shutdown() {
+    // Pop scenes first: scene destructors free SDL textures (tilemaps),
+    // which must happen while the renderer still exists.
+    scenes_.clear(*this);
+
 #ifdef RAVEN_ENABLE_IMGUI
     debug_overlay_.shutdown();
 #endif
     sprites_ = SpriteSheetManager{}; // release all textures before renderer
     renderer_.shutdown();
+    input_.shutdown(); // close gamepad before SDL_Quit
 
     SDL_Quit();
 

--- a/src/core/input.cpp
+++ b/src/core/input.cpp
@@ -26,9 +26,25 @@ Input::Input() {
 }
 
 Input::~Input() {
+    shutdown();
+}
+
+void Input::shutdown() {
     if (gamepad_) {
         SDL_CloseGamepad(gamepad_);
+        gamepad_ = nullptr;
     }
+}
+
+void Input::consume_pressed() {
+    latched_ = EdgeLatch{};
+    current_.shoot_pressed = false;
+    current_.bomb_pressed = false;
+    current_.melee_pressed = false;
+    current_.dash_pressed = false;
+    current_.pause_pressed = false;
+    current_.confirm_pressed = false;
+    current_.cancel_pressed = false;
 }
 
 void Input::set_renderer(SDL_Renderer* renderer) {
@@ -196,13 +212,24 @@ void Input::update_from_gamepad() {
 }
 
 void Input::compute_edges() {
-    current_.shoot_pressed = current_.shoot && !previous_.shoot;
-    current_.bomb_pressed = current_.bomb && !previous_.bomb;
-    current_.melee_pressed = current_.melee && !previous_.melee;
-    current_.dash_pressed = current_.dash && !previous_.dash;
-    current_.pause_pressed = current_.pause && !previous_.pause;
-    current_.confirm_pressed = current_.confirm && !previous_.confirm;
-    current_.cancel_pressed = current_.cancel && !previous_.cancel;
+    // Latch new edges; latches persist across frames until a fixed tick
+    // consumes them (see consume_pressed), so a press on a frame that runs
+    // zero fixed ticks is not lost.
+    latched_.shoot = latched_.shoot || (current_.shoot && !previous_.shoot);
+    latched_.bomb = latched_.bomb || (current_.bomb && !previous_.bomb);
+    latched_.melee = latched_.melee || (current_.melee && !previous_.melee);
+    latched_.dash = latched_.dash || (current_.dash && !previous_.dash);
+    latched_.pause = latched_.pause || (current_.pause && !previous_.pause);
+    latched_.confirm = latched_.confirm || (current_.confirm && !previous_.confirm);
+    latched_.cancel = latched_.cancel || (current_.cancel && !previous_.cancel);
+
+    current_.shoot_pressed = latched_.shoot;
+    current_.bomb_pressed = latched_.bomb;
+    current_.melee_pressed = latched_.melee;
+    current_.dash_pressed = latched_.dash;
+    current_.pause_pressed = latched_.pause;
+    current_.confirm_pressed = latched_.confirm;
+    current_.cancel_pressed = latched_.cancel;
 
     // Clamp movement
     current_.move_x = std::clamp(current_.move_x, -1.f, 1.f);

--- a/src/core/input.hpp
+++ b/src/core/input.hpp
@@ -26,13 +26,17 @@ struct InputState {
     bool confirm = false; ///< Confirm/accept button held this frame.
     bool cancel = false;  ///< Cancel/back button held this frame.
 
-    bool shoot_pressed = false;   ///< Shoot button pressed this frame (edge).
-    bool bomb_pressed = false;    ///< Bomb button pressed this frame (edge).
-    bool melee_pressed = false;   ///< Melee button pressed this frame (edge).
-    bool dash_pressed = false;    ///< Dash button pressed this frame (edge).
-    bool pause_pressed = false;   ///< Pause button pressed this frame (edge).
-    bool confirm_pressed = false; ///< Confirm button pressed this frame (edge).
-    bool cancel_pressed = false;  ///< Cancel button pressed this frame (edge).
+    // Press edges. Latched from the frame the press happens until a fixed
+    // tick consumes them (Input::consume_pressed), so presses are never
+    // dropped on frames that run zero fixed ticks (>120 Hz displays) and
+    // never replayed into multiple ticks of the same frame.
+    bool shoot_pressed = false;   ///< Shoot button press edge.
+    bool bomb_pressed = false;    ///< Bomb button press edge.
+    bool melee_pressed = false;   ///< Melee button press edge.
+    bool dash_pressed = false;    ///< Dash button press edge.
+    bool pause_pressed = false;   ///< Pause button press edge.
+    bool confirm_pressed = false; ///< Confirm button press edge.
+    bool cancel_pressed = false;  ///< Cancel button press edge.
 };
 
 /// @brief Manages keyboard and gamepad input with per-frame edge detection.
@@ -58,6 +62,14 @@ class Input {
     /// no pending SDL events.
     void update();
 
+    /// @brief Clear latched press edges after a fixed tick has seen them.
+    ///
+    /// Call after each fixed-timestep update. Edges latch on the frame the
+    /// press happens and survive frames that run zero fixed ticks, so a
+    /// press always drives exactly one tick regardless of display refresh
+    /// rate relative to the tick rate.
+    void consume_pressed();
+
     /// @brief Get the current input state snapshot.
     /// @return Const reference to the current InputState.
     [[nodiscard]] const InputState& state() const { return current_; }
@@ -74,9 +86,24 @@ class Input {
     /// @return True if the user requested quit (window close or quit key).
     [[nodiscard]] bool quit_requested() const { return quit_; }
 
+    /// @brief Release input devices. Call before SDL_Quit().
+    void shutdown();
+
   private:
+    /// @brief Press edges awaiting consumption by a fixed tick.
+    struct EdgeLatch {
+        bool shoot = false;
+        bool bomb = false;
+        bool melee = false;
+        bool dash = false;
+        bool pause = false;
+        bool confirm = false;
+        bool cancel = false;
+    };
+
     InputState current_;
     InputState previous_;
+    EdgeLatch latched_;
     bool quit_ = false;
 
     const bool* keyboard_ = nullptr;

--- a/src/ecs/components.hpp
+++ b/src/ecs/components.hpp
@@ -37,15 +37,15 @@ struct PreviousTransform {
 
 /// @brief Sprite rendering data referencing a frame within a sprite sheet.
 struct Sprite {
-    StringId sheet_id;       ///< Interned identifier of the SpriteSheet to draw from.
-    int frame_x = 0;         ///< Frame column index in the sheet.
-    int frame_y = 0;         ///< Frame row index in the sheet.
-    int width = 32;          ///< Rendered width in pixels.
-    int height = 32;         ///< Rendered height in pixels.
-    int layer = 0;           ///< Render order (higher values draw on top).
-    bool flip_x = false;     ///< Flip the sprite horizontally when drawing.
-    float offset_x = 0.f;   ///< Horizontal render offset from entity center in pixels.
-    float offset_y = 0.f;   ///< Vertical render offset from entity center in pixels.
+    StringId sheet_id;    ///< Interned identifier of the SpriteSheet to draw from.
+    int frame_x = 0;      ///< Frame column index in the sheet.
+    int frame_y = 0;      ///< Frame row index in the sheet.
+    int width = 32;       ///< Rendered width in pixels.
+    int height = 32;      ///< Rendered height in pixels.
+    int layer = 0;        ///< Render order (higher values draw on top).
+    bool flip_x = false;  ///< Flip the sprite horizontally when drawing.
+    float offset_x = 0.f; ///< Horizontal render offset from entity center in pixels.
+    float offset_y = 0.f; ///< Vertical render offset from entity center in pixels.
 };
 
 /// @brief Frame-based animation state for cycling through sprite frames.
@@ -355,8 +355,13 @@ struct Disarmed {};
 /// @brief Tag: entity is removed when it leaves the play area.
 struct OffScreenDespawn {};
 
-/// @brief Tag: bullet passes through targets instead of being destroyed.
-struct Piercing {};
+/// @brief Bullet passes through targets instead of being destroyed.
+///
+/// Tracks targets already damaged so each is hit only once — without this
+/// a piercing bullet would re-apply damage every tick while overlapping.
+struct Piercing {
+    std::vector<entt::entity> hit; ///< Entities this bullet has already damaged.
+};
 
 /// @brief Tag: marks a decay stabilizer pickup entity.
 struct StabilizerPickup {};

--- a/src/ecs/systems/charged_shot_system.cpp
+++ b/src/ecs/systems/charged_shot_system.cpp
@@ -35,6 +35,14 @@ void update_charged_shot(entt::registry& reg, const InputState& input, float dt)
 
         // Fire on release
         if (!input.shoot && cs.was_shooting && cs.charging) {
+            // Respect the fire-rate cooldown: without this check, rapid
+            // tap-release fires an uncapped stream of min-charge bullets.
+            if (cd.remaining > 0.f) {
+                cs.charge = 0.f;
+                cs.charging = false;
+                cs.was_shooting = input.shoot;
+                continue;
+            }
             float t = cs.charge;
             float damage_mult = cs.min_damage_mult + (cs.max_damage_mult - cs.min_damage_mult) * t;
             float speed_mult = cs.min_speed_mult + (cs.max_speed_mult - cs.min_speed_mult) * t;

--- a/src/ecs/systems/collision_system.cpp
+++ b/src/ecs/systems/collision_system.cpp
@@ -3,6 +3,7 @@
 #include "ecs/components.hpp"
 #include "ecs/systems/hitbox_math.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <vector>
 
@@ -56,16 +57,23 @@ void update_collision(entt::registry& reg) {
         if (bullet.owner != Bullet::Owner::Player)
             continue;
 
+        auto* piercing = reg.try_get<Piercing>(b_ent);
+
         for (auto [e_ent, e_tf, e_hb, enemy, e_hp] : enemies.each()) {
+            // Piercing bullets damage each target once, then pass through
+            if (piercing && std::find(piercing->hit.begin(), piercing->hit.end(), e_ent) !=
+                                piercing->hit.end()) {
+                continue;
+            }
+
             if (circles_overlap(b_tf.x + b_hb.offset_x, b_tf.y + b_hb.offset_y, b_hb.radius,
                                 e_tf.x + e_hb.offset_x, e_tf.y + e_hb.offset_y, e_hb.radius)) {
                 e_hp.current -= dmg.damage;
 
                 // Apply knockback from bullet impact
-                if (reg.any_of<Velocity>(e_ent)) {
-                    auto& b_vel_comp = reg.get<Velocity>(b_ent);
-                    float bvx = b_vel_comp.dx;
-                    float bvy = b_vel_comp.dy;
+                if (const auto* b_vel = reg.try_get<Velocity>(b_ent)) {
+                    float bvx = b_vel->dx;
+                    float bvy = b_vel->dy;
                     float len = std::sqrt(bvx * bvx + bvy * bvy);
                     if (len > 0.f) {
                         reg.emplace_or_replace<Knockback>(e_ent, bvx / len * 150.f,
@@ -73,7 +81,9 @@ void update_collision(entt::registry& reg) {
                     }
                 }
 
-                if (!reg.any_of<Piercing>(b_ent)) {
+                if (piercing) {
+                    piercing->hit.push_back(e_ent);
+                } else {
                     bullets_to_destroy.push_back(b_ent);
                     break; // non-piercing: one hit then destroy
                 }

--- a/src/ecs/systems/dash_system.cpp
+++ b/src/ecs/systems/dash_system.cpp
@@ -2,6 +2,7 @@
 
 #include "ecs/components.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 namespace raven::systems {
@@ -47,8 +48,10 @@ void update_dash(entt::registry& reg, const InputState& input, float dt) {
         reg.emplace<Dash>(entity, dash);
         cooldown.remaining = cooldown.rate;
 
-        // Grant invulnerability (slightly longer than dash for grace period)
-        reg.emplace_or_replace<Invulnerable>(entity, 0.18f);
+        // Grant invulnerability (slightly longer than dash for grace period).
+        // Never shorten i-frames already granted, e.g. by a recent hit.
+        auto& inv = reg.get_or_emplace<Invulnerable>(entity, 0.f);
+        inv.remaining = std::max(inv.remaining, 0.18f);
     }
 
     // Process active dashes: override velocity

--- a/src/ecs/systems/emitter_system.cpp
+++ b/src/ecs/systems/emitter_system.cpp
@@ -83,12 +83,15 @@ void update_emitters(entt::registry& reg, const PatternLibrary& patterns, float 
             continue;
         }
 
-        // Initialize parallel vectors on first use
+        // Initialize parallel vectors on first use. Cooldowns start charged
+        // so a freshly spawned enemy waits one full fire interval before its
+        // first burst instead of firing the instant it appears.
         auto num_emitters = pattern->emitters.size();
         if (emitter.cooldowns.size() != num_emitters) {
-            emitter.cooldowns.resize(num_emitters, 0.f);
+            emitter.cooldowns.resize(num_emitters);
             emitter.current_angles.resize(num_emitters);
             for (size_t i = 0; i < num_emitters; ++i) {
+                emitter.cooldowns[i] = pattern->emitters[i].fire_rate;
                 emitter.current_angles[i] = pattern->emitters[i].start_angle;
             }
         }
@@ -104,13 +107,13 @@ void update_emitters(entt::registry& reg, const PatternLibrary& patterns, float 
             if (emitter.cooldowns[i] > 0.f) {
                 continue;
             }
-            emitter.cooldowns[i] = edef.fire_rate;
 
             // Determine center angle for this burst
             float center_angle = emitter.current_angles[i];
 
             if (edef.type == EmitterDef::Type::Aimed) {
                 if (!has_player) {
+                    // Retry next tick without charging the cooldown
                     continue;
                 }
                 float dx = player_x - tf.x;
@@ -118,6 +121,7 @@ void update_emitters(entt::registry& reg, const PatternLibrary& patterns, float 
                 center_angle = std::atan2(dy, dx) / DEG_TO_RAD;
             }
 
+            emitter.cooldowns[i] = edef.fire_rate;
             fire_burst(reg, edef, center_angle, tf.x, tf.y);
         }
     }

--- a/src/patterns/pattern_library.cpp
+++ b/src/patterns/pattern_library.cpp
@@ -2,11 +2,32 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <fstream>
 
 namespace raven {
 
+namespace {
+
+/// @brief Clamp a parsed value to a safe range, warning when out of bounds.
+float clamp_field(const std::string& pattern, const char* field, float value, float min_v,
+                  float max_v) {
+    if (value < min_v || value > max_v) {
+        float clamped = std::clamp(value, min_v, max_v);
+        spdlog::warn("Pattern '{}': {} = {} out of range [{}, {}], clamped to {}", pattern, field,
+                     value, min_v, max_v, clamped);
+        return clamped;
+    }
+    return value;
+}
+
+} // anonymous namespace
+
 bool PatternLibrary::load_manifest(const std::string& manifest_path) {
+    if (!interner_) {
+        spdlog::error("PatternLibrary: set_interner() must be called before loading");
+        return false;
+    }
     std::ifstream f(manifest_path);
     if (!f.is_open()) {
         spdlog::warn("Pattern manifest '{}' not found", manifest_path);
@@ -30,6 +51,10 @@ bool PatternLibrary::load_manifest(const std::string& manifest_path) {
 }
 
 bool PatternLibrary::load_file(const std::string& file_path) {
+    if (!interner_) {
+        spdlog::error("PatternLibrary: set_interner() must be called before loading");
+        return false;
+    }
     std::ifstream f(file_path);
     if (!f.is_open()) {
         spdlog::error("Failed to open pattern file '{}'", file_path);
@@ -50,6 +75,10 @@ bool PatternLibrary::load_file(const std::string& file_path) {
 }
 
 bool PatternLibrary::load_from_json(const nlohmann::json& j) {
+    if (!interner_) {
+        spdlog::error("PatternLibrary: set_interner() must be called before loading");
+        return false;
+    }
     try {
         auto pattern = parse_pattern(j);
         auto name = pattern.name;
@@ -89,13 +118,14 @@ PatternDef PatternLibrary::parse_pattern(const nlohmann::json& j) const {
         def.tier = Weapon::Tier::Common;
 
     for (const auto& ej : j.at("emitters")) {
-        def.emitters.push_back(parse_emitter(ej));
+        def.emitters.push_back(parse_emitter(ej, def.name));
     }
 
     return def;
 }
 
-EmitterDef PatternLibrary::parse_emitter(const nlohmann::json& j) const {
+EmitterDef PatternLibrary::parse_emitter(const nlohmann::json& j,
+                                         const std::string& pattern_name) const {
     EmitterDef def;
 
     auto type_str = j.value("type", "radial");
@@ -106,10 +136,14 @@ EmitterDef PatternLibrary::parse_emitter(const nlohmann::json& j) const {
     else
         def.type = EmitterDef::Type::Radial;
 
-    def.count = j.value("count", 1);
+    // Clamp values that could destabilize the game if mistyped in data:
+    // fire_rate <= 0 fires a burst every tick (runaway entity growth), and
+    // huge counts spawn thousands of bullets per burst.
+    def.count = static_cast<int>(
+        clamp_field(pattern_name, "count", static_cast<float>(j.value("count", 1)), 1.f, 256.f));
     def.speed = j.value("speed", 100.f);
     def.angular_velocity = j.value("angular_velocity", 0.f);
-    def.fire_rate = j.value("fire_rate", 0.1f);
+    def.fire_rate = clamp_field(pattern_name, "fire_rate", j.value("fire_rate", 0.1f), 0.05f, 60.f);
     def.spread_angle = j.value("spread_angle", 360.f);
     def.start_angle = j.value("start_angle", 0.f);
     def.bullet_sheet = interner_->intern(j.value("bullet_sheet", "projectiles"));
@@ -117,9 +151,10 @@ EmitterDef PatternLibrary::parse_emitter(const nlohmann::json& j) const {
     def.bullet_frame_y = j.value("bullet_frame_y", 0);
     def.bullet_width = j.value("bullet_width", 8);
     def.bullet_height = j.value("bullet_height", 8);
-    def.lifetime = j.value("lifetime", 5.f);
+    def.lifetime = clamp_field(pattern_name, "lifetime", j.value("lifetime", 5.f), 0.05f, 60.f);
     def.damage = j.value("damage", 1.f);
-    def.hitbox_radius = j.value("hitbox_radius", 3.f);
+    def.hitbox_radius =
+        clamp_field(pattern_name, "hitbox_radius", j.value("hitbox_radius", 3.f), 0.f, 64.f);
 
     return def;
 }

--- a/src/patterns/pattern_library.hpp
+++ b/src/patterns/pattern_library.hpp
@@ -82,7 +82,7 @@ class PatternLibrary {
     StringInterner* interner_ = nullptr;
 
     PatternDef parse_pattern(const nlohmann::json& j) const;
-    EmitterDef parse_emitter(const nlohmann::json& j) const;
+    EmitterDef parse_emitter(const nlohmann::json& j, const std::string& pattern_name) const;
 };
 
 } // namespace raven

--- a/src/scenes/game_scene.cpp
+++ b/src/scenes/game_scene.cpp
@@ -46,6 +46,11 @@ void GameScene::on_enter(Game& game) {
     pattern_lib_.load_manifest("assets/data/patterns/manifest.json");
 
     game.registry().ctx().emplace<std::mt19937>(std::random_device{}());
+
+    // Erase any stale GameState first: ctx().emplace is a no-op when the
+    // value already exists, and the victory path (swap to TitleScene) does
+    // not go through GameOverScene::on_exit, which normally erases it.
+    game.registry().ctx().erase<GameState>();
     auto& game_state = game.registry().ctx().emplace<GameState>();
     game_state.player_class = selected_class_;
 

--- a/src/scenes/scene.hpp
+++ b/src/scenes/scene.hpp
@@ -34,6 +34,10 @@ class Scene {
 /// @brief Stack-based scene manager. The top scene receives updates and renders.
 ///
 /// Supports push (for overlays like pause menus) and swap (for transitions).
+///
+/// Transitions requested from inside a scene's update() are deferred and
+/// applied after the update returns — popping a scene destroys it, so
+/// applying immediately would free the scene that is still executing.
 class SceneManager {
   public:
     /// @brief Push a scene onto the stack, becoming the active scene.
@@ -50,6 +54,13 @@ class SceneManager {
     /// @param game The Game instance passed to on_exit() and on_enter().
     void swap(std::unique_ptr<Scene> scene, Game& game);
 
+    /// @brief Pop all scenes, calling on_exit() on each from top to bottom.
+    ///
+    /// Must not be called from inside a scene's update(). Use during game
+    /// shutdown so scene destructors run while SDL resources still exist.
+    /// @param game The Game instance passed to on_exit().
+    void clear(Game& game);
+
     /// @brief Update the top scene.
     /// @param game The Game instance.
     /// @param dt Fixed timestep delta in seconds.
@@ -64,7 +75,16 @@ class SceneManager {
     [[nodiscard]] bool empty() const { return stack_.empty(); }
 
   private:
+    /// @brief A push/pop/swap requested during update(), applied afterwards.
+    struct PendingOp {
+        enum class Kind : uint8_t { Push, Pop, Swap };
+        Kind kind;
+        std::unique_ptr<Scene> scene; ///< Null for Pop.
+    };
+
     std::vector<std::unique_ptr<Scene>> stack_;
+    std::vector<PendingOp> pending_;
+    bool updating_ = false; ///< True while the top scene's update() runs.
 };
 
 } // namespace raven

--- a/src/scenes/scene_manager.cpp
+++ b/src/scenes/scene_manager.cpp
@@ -3,11 +3,19 @@
 namespace raven {
 
 void SceneManager::push(std::unique_ptr<Scene> scene, Game& game) {
+    if (updating_) {
+        pending_.push_back({PendingOp::Kind::Push, std::move(scene)});
+        return;
+    }
     scene->on_enter(game);
     stack_.push_back(std::move(scene));
 }
 
 void SceneManager::pop(Game& game) {
+    if (updating_) {
+        pending_.push_back({PendingOp::Kind::Pop, nullptr});
+        return;
+    }
     if (!stack_.empty()) {
         stack_.back()->on_exit(game);
         stack_.pop_back();
@@ -15,13 +23,45 @@ void SceneManager::pop(Game& game) {
 }
 
 void SceneManager::swap(std::unique_ptr<Scene> scene, Game& game) {
+    if (updating_) {
+        pending_.push_back({PendingOp::Kind::Swap, std::move(scene)});
+        return;
+    }
     pop(game);
     push(std::move(scene), game);
 }
 
+void SceneManager::clear(Game& game) {
+    while (!stack_.empty()) {
+        pop(game);
+    }
+    pending_.clear();
+}
+
 void SceneManager::update(Game& game, float dt) {
     if (!stack_.empty()) {
+        updating_ = true;
         stack_.back()->update(game, dt);
+        updating_ = false;
+    }
+
+    // Apply transitions requested during update. Move the queue out first:
+    // on_enter/on_exit may request further transitions, which now apply
+    // immediately (updating_ is false) without invalidating this loop.
+    std::vector<PendingOp> ops = std::move(pending_);
+    pending_.clear();
+    for (auto& op : ops) {
+        switch (op.kind) {
+        case PendingOp::Kind::Push:
+            push(std::move(op.scene), game);
+            break;
+        case PendingOp::Kind::Pop:
+            pop(game);
+            break;
+        case PendingOp::Kind::Swap:
+            swap(std::move(op.scene), game);
+            break;
+        }
     }
 }
 

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -38,7 +38,7 @@ void TitleScene::render(Game& game) {
 
     // Blinking "press start" indicator
     if (show_prompt_) {
-        SDL_FRect prompt_rect{132.f, 300.f, 120.f, 16.f};
+        SDL_FRect prompt_rect{132.f, 200.f, 120.f, 16.f};
         SDL_SetRenderDrawColor(r, 255, 255, 255, 255);
         SDL_RenderFillRect(r, &prompt_rect);
     }

--- a/tests/test_collision.cpp
+++ b/tests/test_collision.cpp
@@ -228,6 +228,26 @@ TEST_CASE("Player bullet vs enemy collision", "[collision]") {
         REQUIRE(hp.current == Catch::Approx(2.f));
     }
 
+    SECTION("Piercing bullet damages each enemy only once while overlapping") {
+        auto bullet = reg.create();
+        reg.emplace<Transform2D>(bullet, 103.f, 100.f); // overlaps enemy
+        reg.emplace<CircleHitbox>(bullet, 3.f, 0.f, 0.f);
+        reg.emplace<Bullet>(bullet, Bullet::Owner::Player);
+        reg.emplace<DamageOnContact>(bullet, 1.f);
+        reg.emplace<Piercing>(bullet);
+
+        // Simulate several ticks with the bullet still inside the enemy
+        systems::update_collision(reg);
+        systems::update_collision(reg);
+        systems::update_collision(reg);
+
+        REQUIRE(reg.valid(bullet));
+
+        // Damage applied exactly once, not once per tick
+        auto& hp = reg.get<Health>(enemy);
+        REQUIRE(hp.current == Catch::Approx(2.f));
+    }
+
     SECTION("Piercing bullet hits multiple enemies") {
         auto enemy2 = reg.create();
         reg.emplace<Transform2D>(enemy2, 103.f, 100.f); // same spot

--- a/tests/test_emitters.cpp
+++ b/tests/test_emitters.cpp
@@ -23,6 +23,14 @@ int count_bullets(entt::registry& reg) {
     return count;
 }
 
+/// @brief Run the emitter system for a number of fixed ticks.
+void run_ticks(entt::registry& reg, const PatternLibrary& patterns, int ticks) {
+    constexpr float dt = 1.f / 120.f;
+    for (int i = 0; i < ticks; ++i) {
+        raven::systems::update_emitters(reg, patterns, dt);
+    }
+}
+
 /// @brief Load a simple radial pattern into the library.
 void load_radial_pattern(PatternLibrary& lib, const std::string& name, int count, float speed,
                          float fire_rate, float spread_angle) {
@@ -45,7 +53,7 @@ TEST_CASE("Emitter system", "[emitters]") {
     patterns.set_interner(interner);
     constexpr float dt = 1.f / 120.f;
 
-    SECTION("Radial emitter fires on first tick") {
+    SECTION("Radial emitter fires after one full fire interval") {
         load_radial_pattern(patterns, "test_radial", 3, 100.f, 0.1f, 360.f);
 
         auto enemy = reg.create();
@@ -54,7 +62,12 @@ TEST_CASE("Emitter system", "[emitters]") {
         emitter.pattern_name = interner.intern("test_radial");
         reg.emplace<BulletEmitter>(enemy, std::move(emitter));
 
+        // Cooldowns start charged: no burst the instant an enemy spawns
         systems::update_emitters(reg, patterns, dt);
+        REQUIRE(count_bullets(reg) == 0);
+
+        // After the fire interval elapses (0.1s = 12 ticks), the burst fires
+        run_ticks(reg, patterns, 12);
 
         // Should fire 3 bullets (radial, 360 degrees)
         REQUIRE(count_bullets(reg) == 3);
@@ -75,11 +88,11 @@ TEST_CASE("Emitter system", "[emitters]") {
         emitter.pattern_name = interner.intern("cooldown_test");
         reg.emplace<BulletEmitter>(enemy, std::move(emitter));
 
-        // First tick fires
-        systems::update_emitters(reg, patterns, dt);
+        // Fires once the initial 1.0s cooldown elapses (120 ticks)
+        run_ticks(reg, patterns, 121);
         REQUIRE(count_bullets(reg) == 1);
 
-        // Second tick should not fire (cooldown = 1.0s, dt ~= 0.008s)
+        // Next tick should not fire again (cooldown = 1.0s, dt ~= 0.008s)
         systems::update_emitters(reg, patterns, dt);
         REQUIRE(count_bullets(reg) == 1);
     }
@@ -94,7 +107,7 @@ TEST_CASE("Emitter system", "[emitters]") {
         emitter.active = false;
         reg.emplace<BulletEmitter>(enemy, std::move(emitter));
 
-        systems::update_emitters(reg, patterns, dt);
+        run_ticks(reg, patterns, 30);
 
         REQUIRE(count_bullets(reg) == 0);
     }
@@ -106,7 +119,7 @@ TEST_CASE("Emitter system", "[emitters]") {
         emitter.pattern_name = interner.intern("nonexistent");
         reg.emplace<BulletEmitter>(enemy, std::move(emitter));
 
-        systems::update_emitters(reg, patterns, dt);
+        run_ticks(reg, patterns, 30);
 
         REQUIRE(count_bullets(reg) == 0);
     }
@@ -133,7 +146,8 @@ TEST_CASE("Emitter system", "[emitters]") {
         emitter.pattern_name = interner.intern("aimed_test");
         reg.emplace<BulletEmitter>(enemy, std::move(emitter));
 
-        systems::update_emitters(reg, patterns, dt);
+        // fire_rate 0.1s = 12 ticks of initial cooldown
+        run_ticks(reg, patterns, 13);
 
         REQUIRE(count_bullets(reg) == 1);
 
@@ -154,8 +168,10 @@ TEST_CASE("Emitter system", "[emitters]") {
         emitter.pattern_name = interner.intern("pos_test");
         reg.emplace<BulletEmitter>(enemy, std::move(emitter));
 
-        systems::update_emitters(reg, patterns, dt);
+        // fire_rate 0.1s = 12 ticks of initial cooldown
+        run_ticks(reg, patterns, 13);
 
+        REQUIRE(count_bullets(reg) == 1);
         auto bullet_view = reg.view<Bullet, Transform2D>();
         for (auto [entity, bullet, tf] : bullet_view.each()) {
             REQUIRE(tf.x == Catch::Approx(123.f));

--- a/tests/test_patterns.cpp
+++ b/tests/test_patterns.cpp
@@ -120,6 +120,34 @@ TEST_CASE("PatternLibrary load_from_json", "[patterns]") {
         REQUIRE_FALSE(lib.load_from_json(j));
     }
 
+    SECTION("Loading without an interner fails instead of crashing") {
+        PatternLibrary no_interner;
+        nlohmann::json j = {{"name", "orphan"}, {"emitters", {{{"type", "radial"}}}}};
+
+        REQUIRE_FALSE(no_interner.load_from_json(j));
+    }
+
+    SECTION("Unsafe numeric values are clamped") {
+        // fire_rate <= 0 would fire a burst every tick; count is capped to
+        // prevent thousands of bullets per burst from a data typo.
+        nlohmann::json j = {{"name", "hostile"},
+                            {"emitters",
+                             {{{"type", "radial"},
+                               {"count", 100000},
+                               {"fire_rate", 0.f},
+                               {"lifetime", -1.f},
+                               {"hitbox_radius", -3.f}}}}};
+
+        REQUIRE(lib.load_from_json(j));
+
+        const auto* pat = lib.get("hostile");
+        REQUIRE(pat != nullptr);
+        REQUIRE(pat->emitters[0].count <= 256);
+        REQUIRE(pat->emitters[0].fire_rate > 0.f);
+        REQUIRE(pat->emitters[0].lifetime > 0.f);
+        REQUIRE(pat->emitters[0].hitbox_radius >= 0.f);
+    }
+
     SECTION("names() returns loaded pattern names") {
         nlohmann::json j1 = {{"name", "alpha"}, {"emitters", {{{"type", "radial"}}}}};
         nlohmann::json j2 = {{"name", "beta"}, {"emitters", {{{"type", "aimed"}}}}};


### PR DESCRIPTION
The bootstrapper defined CPM_HASH_SUM but never passed it to
file(DOWNLOAD). Passing EXPECTED_HASH verifies integrity and also skips
the network fetch when the file already matches, so reconfigures work
offline or behind restrictive proxies instead of truncating the cached
copy to zero bytes.