### PR TITLE
ci: add GitHub Actions workflow for format, build, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "claude/**"]
+  pull_request:
+
+env:
+  # Ubuntu 24.04 has no SDL3 packages; build from source and cache the prefix.
+  SDL_TAG: release-3.4.12
+  SDL_IMAGE_TAG: release-3.2.4
+  SDL_PREFIX: /home/runner/sdl-install
+  CPM_SOURCE_CACHE: /home/runner/.cache/cpm
+
+jobs:
+  format:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check clang-format
+        run: |
+          find src tests -name '*.cpp' -o -name '*.hpp' \
+            | xargs clang-format --dry-run --Werror
+
+  build-test:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ninja-build pkg-config \
+            libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev \
+            libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev \
+            libegl1-mesa-dev libgl1-mesa-dev libasound2-dev libpulse-dev libudev-dev
+
+      - name: Cache SDL3 install
+        id: cache-sdl
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SDL_PREFIX }}
+          key: sdl-${{ env.SDL_TAG }}-${{ env.SDL_IMAGE_TAG }}-${{ runner.os }}-24.04
+
+      - name: Build SDL3 from source
+        if: steps.cache-sdl.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$SDL_TAG" https://github.com/libsdl-org/SDL.git /tmp/SDL
+          cmake -S /tmp/SDL -B /tmp/SDL/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$SDL_PREFIX" \
+            -DSDL_TEST_LIBRARY=OFF -DSDL_EXAMPLES=OFF
+          ninja -C /tmp/SDL/build install
+
+          git clone --depth 1 --branch "$SDL_IMAGE_TAG" https://github.com/libsdl-org/SDL_image.git /tmp/SDL_image
+          cmake -S /tmp/SDL_image -B /tmp/SDL_image/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$SDL_PREFIX" \
+            -DCMAKE_PREFIX_PATH="$SDL_PREFIX" \
+            -DSDLIMAGE_SAMPLES=OFF -DSDLIMAGE_TESTS=OFF \
+            -DSDLIMAGE_AVIF=OFF -DSDLIMAGE_WEBP=OFF -DSDLIMAGE_TIF=OFF -DSDLIMAGE_JXL=OFF
+          ninja -C /tmp/SDL_image/build install
+
+      - name: Cache CPM packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CPM_SOURCE_CACHE }}
+          key: cpm-${{ hashFiles('cmake/Dependencies.cmake', 'cmake/CPM.cmake') }}
+
+      - name: Configure
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_PREFIX_PATH="$SDL_PREFIX"
+        env:
+          PKG_CONFIG_PATH: ${{ env.SDL_PREFIX }}/lib/pkgconfig
+
+      - name: Build
+        run: ninja -C build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+        env:
+          LD_LIBRARY_PATH: ${{ env.SDL_PREFIX }}/lib
+          SDL_VIDEODRIVER: dummy


### PR DESCRIPTION
Adds the CI pipeline that was flagged as missing in the Steam-readiness review. Runs on pushes to `main`, pushes to `claude/**` branches, and all pull requests.

## Jobs

**format** — `clang-format --dry-run --Werror` over all of `src/` and `tests/`. The whole tree currently conforms, so this starts green.

**build-test (Debug / Release matrix)** — on `ubuntu-24.04`:
- Builds **SDL 3.4.12** and **SDL3_image 3.2.4 from source** into a cached prefix — no distro packages exist for SDL3 yet, and the project requires >= 3.4 for `SDL_SCALEMODE_PIXELART`. Cold build costs ~70s; warm runs restore from cache in seconds.
- Caches CPM package sources (safe to cache thanks to the `EXPECTED_HASH` verification added in #8).
- Configures with the project's full warning set, builds, and runs all 98 Catch2 tests via ctest with `SDL_VIDEODRIVER=dummy`.

## Verification

This run already validated itself on the branch — all three jobs green on the first attempt: [run #1](https://github.com/adanoelle/raven/actions/runs/28689072030) (format 3s, Debug and Release each ~4.5 min cold).

After merging, consider adding branch protection on `main` requiring the `format` and `build-test` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiNf1uVLdvAesmET4ynY3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiNf1uVLdvAesmET4ynY3a)_