### PR TITLE
feat: Windows/MSVC build support and optional Steamworks integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,31 @@ jobs:
           LD_LIBRARY_PATH: ${{ env.SDL_PREFIX }}/lib
           SDL_VIDEODRIVER: dummy
           SDL_AUDIODRIVER: dummy
+
+  build-test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache CPM packages
+        uses: actions/cache@v4
+        with:
+          path: C:\cpm-cache
+          key: cpm-windows-${{ hashFiles('cmake/Dependencies.cmake', 'cmake/CPM.cmake') }}
+
+      # No SDL3 packages or pkg-config on Windows: RAVEN_BUNDLED_DEPS builds
+      # SDL3/SDL3_image from source via CPM alongside the other dependencies.
+      - name: Configure
+        run: >
+          cmake -B build
+          -DRAVEN_BUNDLED_DEPS=ON
+          -DCPM_SOURCE_CACHE=C:\cpm-cache
+
+      - name: Build
+        run: cmake --build build --config Debug --parallel
+
+      - name: Test
+        run: ctest --test-dir build -C Debug --output-on-failure
+        env:
+          SDL_VIDEODRIVER: dummy
+          SDL_AUDIODRIVER: dummy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ just lint     # clang-tidy
 
 src/audio/       SDL3-native sound effects (AudioEngine + AudioQueue events)
 src/core/        Game loop (120Hz fixed timestep), input
+src/platform/    Optional Steamworks wrapper (no-op without RAVEN_ENABLE_STEAM)
 src/ecs/         components.hpp + systems/ (one file per system)
 src/rendering/   SDL_Renderer wrapper, 480x270 virtual res, sprite sheets
 src/scenes/      Stack-based scene manager

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 option(RAVEN_ENABLE_TESTS "Build tests" ON)
 option(RAVEN_ENABLE_ASAN "Enable Address Sanitizer" OFF)
 option(RAVEN_ENABLE_IMGUI "Enable Dear ImGui debug overlay" ON)
+option(RAVEN_ENABLE_STEAM "Enable Steamworks (needs SDK in vendor/steamworks/sdk)" OFF)
 
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -40,6 +41,9 @@ add_executable(raven
 
     # Audio
     src/audio/audio_engine.cpp
+
+    # Platform
+    src/platform/steam.cpp
 
     # Rendering
     src/rendering/renderer.cpp
@@ -103,15 +107,38 @@ if(RAVEN_ENABLE_IMGUI)
     target_sources(raven PRIVATE src/debug/debug_overlay.cpp)
 endif()
 
+if(RAVEN_ENABLE_STEAM)
+    include(Steamworks)
+    target_link_libraries(raven PRIVATE steamworks::steamworks)
+    target_compile_definitions(raven PRIVATE RAVEN_ENABLE_STEAM)
+endif()
+
 raven_set_warnings(raven)
 
-# Copy assets to build directory
-add_custom_command(TARGET raven POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${CMAKE_SOURCE_DIR}/assets
-        ${CMAKE_BINARY_DIR}/bin/assets
-    COMMENT "Symlinking assets directory"
-)
+# Make assets available next to the built binary (SDL_GetBasePath lookup).
+# Symlinks need developer mode on Windows, so copy there instead.
+if(WIN32)
+    add_custom_command(TARGET raven POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/assets
+            $<TARGET_FILE_DIR:raven>/assets
+        COMMENT "Copying assets directory"
+    )
+    # Shared dependencies (SDL3.dll, SDL3_image.dll) must sit next to the exe
+    add_custom_command(TARGET raven POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_RUNTIME_DLLS:raven> $<TARGET_FILE_DIR:raven>
+        COMMAND_EXPAND_LISTS
+        COMMENT "Copying runtime DLLs"
+    )
+else()
+    add_custom_command(TARGET raven POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+            ${CMAKE_SOURCE_DIR}/assets
+            ${CMAKE_BINARY_DIR}/bin/assets
+        COMMENT "Symlinking assets directory"
+    )
+endif()
 
 # ── Tests ─────────────────────────────────────────────────────────
 if(RAVEN_ENABLE_TESTS)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -26,5 +26,11 @@ function(raven_set_warnings target)
             -Wlogical-op
             -Wuseless-cast
         >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /W4
+            /permissive-
+            /utf-8
+            /Zc:__cplusplus
+        >
     )
 endfunction()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -2,15 +2,53 @@
 
 include(CPM)
 
-# ── System packages (found via pkg-config / CMake find modules) ───
-find_package(PkgConfig REQUIRED)
-# 3.4 is the floor: SDL_SCALEMODE_PIXELART (renderer, tilemap) needs it
-find_package(SDL3 3.4 REQUIRED)
-pkg_check_modules(sdl3-image REQUIRED IMPORTED_TARGET sdl3-image)
+# ── SDL3 / SDL3_image ──────────────────────────────────────────────
+# Prefer system packages (Nix dev shell, cached CI prefix); fall back to
+# building from source via CPM when they are absent — the normal case on
+# Windows/MSVC, where no SDL3 distro packages or pkg-config exist.
+option(RAVEN_BUNDLED_DEPS "Build SDL3/SDL3_image from source even if system packages exist" OFF)
 
-# Create alias targets for consistent naming
+if(NOT RAVEN_BUNDLED_DEPS)
+    # 3.4 is the floor: SDL_SCALEMODE_PIXELART (renderer, tilemap) needs it
+    find_package(SDL3 3.4 QUIET)
+    find_package(PkgConfig QUIET)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(sdl3-image QUIET IMPORTED_TARGET sdl3-image)
+    endif()
+endif()
+
+if(NOT TARGET SDL3::SDL3)
+    message(STATUS "System SDL3 not found — building from source (release-3.4.12)")
+    CPMAddPackage(
+        NAME SDL3
+        GITHUB_REPOSITORY libsdl-org/SDL
+        GIT_TAG release-3.4.12
+        SYSTEM YES
+        OPTIONS
+            "SDL_TEST_LIBRARY OFF"
+            "SDL_EXAMPLES OFF"
+    )
+endif()
+
 if(NOT TARGET SDL3_image::SDL3_image)
-    add_library(SDL3_image::SDL3_image ALIAS PkgConfig::sdl3-image)
+    if(TARGET PkgConfig::sdl3-image)
+        add_library(SDL3_image::SDL3_image ALIAS PkgConfig::sdl3-image)
+    else()
+        message(STATUS "System SDL3_image not found — building from source (release-3.2.4)")
+        CPMAddPackage(
+            NAME SDL3_image
+            GITHUB_REPOSITORY libsdl-org/SDL_image
+            GIT_TAG release-3.2.4
+            SYSTEM YES
+            OPTIONS
+                "SDLIMAGE_SAMPLES OFF"
+                "SDLIMAGE_TESTS OFF"
+                "SDLIMAGE_AVIF OFF"
+                "SDLIMAGE_WEBP OFF"
+                "SDLIMAGE_TIF OFF"
+                "SDLIMAGE_JXL OFF"
+        )
+    endif()
 endif()
 
 # ── CPM dependencies (header-only or compiled from source) ────────

--- a/cmake/Steamworks.cmake
+++ b/cmake/Steamworks.cmake
@@ -1,0 +1,53 @@
+# Steamworks.cmake — optional Steamworks SDK integration
+#
+# The SDK is distributed under Valve's partner agreement and cannot be
+# committed to the repository (vendor/steamworks/ is gitignored for it).
+# To enable:
+#   1. Download the Steamworks SDK from https://partner.steamgames.com
+#   2. Unzip so the layout is vendor/steamworks/sdk/public/steam/steam_api.h
+#   3. Configure with -DRAVEN_ENABLE_STEAM=ON
+#
+# During development, place a steam_appid.txt (containing your app id, or
+# 480 for Valve's SpaceWar test app) next to the built binary so
+# SteamAPI_Init can attach without a Steam launch. Do not ship that file.
+
+set(STEAM_SDK_DIR "${CMAKE_SOURCE_DIR}/vendor/steamworks/sdk")
+
+if(NOT EXISTS "${STEAM_SDK_DIR}/public/steam/steam_api.h")
+    message(FATAL_ERROR
+        "RAVEN_ENABLE_STEAM is ON but the Steamworks SDK was not found at\n"
+        "  ${STEAM_SDK_DIR}\n"
+        "Download it from https://partner.steamgames.com and unzip so that\n"
+        "  vendor/steamworks/sdk/public/steam/steam_api.h exists,\n"
+        "or configure with -DRAVEN_ENABLE_STEAM=OFF.")
+endif()
+
+add_library(steamworks SHARED IMPORTED)
+target_include_directories(steamworks INTERFACE "${STEAM_SDK_DIR}/public")
+
+if(WIN32)
+    set_target_properties(steamworks PROPERTIES
+        IMPORTED_LOCATION "${STEAM_SDK_DIR}/redistributable_bin/win64/steam_api64.dll"
+        IMPORTED_IMPLIB "${STEAM_SDK_DIR}/redistributable_bin/win64/steam_api64.lib"
+    )
+elseif(APPLE)
+    set_target_properties(steamworks PROPERTIES
+        IMPORTED_LOCATION "${STEAM_SDK_DIR}/redistributable_bin/osx/libsteam_api.dylib"
+    )
+else()
+    set_target_properties(steamworks PROPERTIES
+        IMPORTED_LOCATION "${STEAM_SDK_DIR}/redistributable_bin/linux64/libsteam_api.so"
+    )
+endif()
+
+add_library(steamworks::steamworks ALIAS steamworks)
+
+# The redistributable must ship (and run) next to the game binary
+add_custom_command(TARGET raven POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "$<TARGET_PROPERTY:steamworks,IMPORTED_LOCATION>"
+        "$<TARGET_FILE_DIR:raven>"
+    COMMENT "Copying Steamworks redistributable"
+)
+
+message(STATUS "Steamworks SDK enabled: ${STEAM_SDK_DIR}")

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -73,6 +73,7 @@
 - [SDL3 Migration](devlog/2026-02-12-sdl3-migration.md)
 - [Steam Readiness Sprint](devlog/2026-07-03-steam-readiness-sprint.md)
 - [Options Menu and Sound Effects](devlog/2026-07-05-options-and-audio.md)
+- [Windows Builds and Steamworks Scaffolding](devlog/2026-07-06-windows-and-steamworks.md)
 
 ---
 
@@ -97,3 +98,5 @@
 - [ADR-0017: User Settings in the Platform Pref Path](decisions/0017-settings-pref-path.md)
 - [ADR-0018: Bitmap Font Atlas for Text Rendering](decisions/0018-bitmap-font-text.md)
 - [ADR-0019: Sound Effects on Native SDL3 Audio](decisions/0019-sdl3-native-audio.md)
+- [ADR-0020: Bundled Dependency Fallback for Windows Builds](decisions/0020-bundled-dependency-fallback.md)
+- [ADR-0021: Optional Steamworks Integration](decisions/0021-optional-steamworks.md)

--- a/docs/book/src/decisions/0020-bundled-dependency-fallback.md
+++ b/docs/book/src/decisions/0020-bundled-dependency-fallback.md
@@ -1,0 +1,53 @@
+# 20. Bundled Dependency Fallback for Windows Builds
+
+Date: 2026-07-06 Status: Accepted
+
+## Context
+
+Dependency discovery was Linux-shaped: `find_package(SDL3)` against system
+packages and `pkg_check_modules` for SDL3_image, with `PkgConfig` marked
+`REQUIRED`. On Windows/MSVC none of that exists — no SDL3 distro packages,
+usually no pkg-config — so the project simply could not configure on the
+platform where most Steam sales happen.
+
+The other dependencies (EnTT, nlohmann_json, spdlog, LDtkLoader, Catch2,
+ImGui) already build from source via CPM on every platform; SDL was the only
+system-package holdout, kept that way because the Nix dev shell and the
+cached CI prefix provide it faster than a source build.
+
+## Decision
+
+**System packages first, CPM source build as fallback.** `find_package(SDL3
+3.4 QUIET)` and an optional pkg-config probe run first; if the targets don't
+materialise, `CPMAddPackage` builds SDL 3.4.12 / SDL3_image 3.2.4 from
+source, pinned to the same versions CI compiles on Linux.
+`-DRAVEN_BUNDLED_DEPS=ON` forces the source path even when system packages
+exist (used by Windows CI, and useful for reproducing Windows-shaped builds
+on Linux).
+
+Windows-specific build fixes ride along:
+
+- Assets are **copied** next to the binary instead of symlinked (symlinks
+  need developer mode on Windows), and `$<TARGET_RUNTIME_DLLS>` post-build
+  steps place SDL3.dll et al. beside both the game and test executables.
+- MSVC gets real warning flags (`/W4 /permissive- /Zc:__cplusplus`) and
+  `/utf-8` — sources contain UTF-8 punctuation that MSVC would otherwise
+  misread under a system codepage.
+- CI gains a `windows-latest` job: MSVC + bundled deps + full test suite.
+
+## Consequences
+
+**Positive:**
+
+- `cmake -B build` works on a bare Windows machine with only Visual Studio
+  installed; no vcpkg, MSYS2, or manual SDK downloads
+- Linux dev-shell and CI paths are unchanged (system packages still win)
+- One pinned SDL version everywhere; version skew between platforms is
+  impossible to miss
+
+**Negative:**
+
+- Cold Windows CI builds compile SDL from source (~minutes); CPM source
+  caching softens repeats but object files rebuild per run
+- The fallback is a second configure path to keep working — exercised
+  continuously by the Windows CI job, and locally via `RAVEN_BUNDLED_DEPS=ON`

--- a/docs/book/src/decisions/0021-optional-steamworks.md
+++ b/docs/book/src/decisions/0021-optional-steamworks.md
@@ -1,0 +1,60 @@
+# 21. Optional Steamworks Integration
+
+Date: 2026-07-06 Status: Accepted
+
+## Context
+
+Shipping on Steam ultimately wants the Steamworks SDK — achievements, rich
+presence, Steam Input, and (for some features) the overlay. But the SDK is
+distributed under Valve's partner agreement and cannot be committed to the
+repository; `vendor/steamworks/` has been gitignored for it since the repo's
+early days. The build must therefore work fully without the SDK, and every
+contributor (and CI) must be able to compile without a partner account.
+
+## Decision
+
+**Steamworks is an opt-in build flag with a no-op fallback.**
+
+- `-DRAVEN_ENABLE_STEAM=ON` activates `cmake/Steamworks.cmake`, which
+  expects the SDK unzipped at `vendor/steamworks/sdk` (a clear fatal error
+  explains the layout if it's missing), links the per-platform
+  redistributable (`steam_api64` / `libsteam_api`), and copies it next to
+  the game binary post-build.
+- `src/platform/steam.hpp` exposes a thin `Steam` wrapper — `init()`,
+  `run_callbacks()`, `shutdown()`, `is_active()`. The implementation is
+  `#ifdef RAVEN_ENABLE_STEAM`; without the flag every method is a no-op and
+  `is_active()` stays false, so call sites never carry ifdefs.
+- Runtime failure is non-fatal: SDK built in but Steam not running (or no
+  `steam_appid.txt` during development) logs a warning and the game runs
+  without Steam features — the same degradation philosophy as audio, fonts,
+  and sprites.
+- `Game` owns the wrapper: init after SDL, `SteamAPI_RunCallbacks` pumped
+  once per frame, shutdown before `SDL_Quit`.
+
+Development flow: drop the SDK zip contents into `vendor/steamworks/sdk`,
+place a `steam_appid.txt` (the app id, or `480` for Valve's SpaceWar test
+app) next to the built binary, configure with the flag. Neither the SDK nor
+the appid file is ever committed or shipped in the depot (Steam provides the
+appid at launch).
+
+Future Steam features (achievements, rich presence, Steam Input action sets)
+extend the `Steam` wrapper behind the same flag; gameplay code observes
+`is_active()` rather than the define.
+
+## Consequences
+
+**Positive:**
+
+- The default build has zero Steam coupling; CI and contributors need no SDK
+- One wrapper class is the only place `steam_api.h` is included — the API
+  surface in use is auditable at a glance
+- Graceful runtime fallback means one binary works both under Steam and
+  standalone during development
+
+**Negative:**
+
+- The real-SDK build path can't run in CI (SDK can't be distributed); it is
+  compile-verified locally against a minimal mock and will get true
+  verification once a partner account and app id exist
+- Overlay/DRM specifics (launch-under-Steam requirements,
+  `SteamAPI_RestartAppIfNecessary`) are deferred until an app id exists

--- a/docs/book/src/devlog/2026-07-06-windows-and-steamworks.md
+++ b/docs/book/src/devlog/2026-07-06-windows-and-steamworks.md
@@ -1,0 +1,57 @@
+# Windows Builds and Steamworks Scaffolding
+
+Date: 2026-07-06 Tags: windows, msvc, ci, steamworks, build
+
+## What Changed
+
+The two remaining platform items from the Steam-readiness review: the build
+now works on Windows/MSVC, and the Steamworks integration point exists as an
+opt-in flag.
+
+## Windows Build
+
+[ADR-0020](../decisions/0020-bundled-dependency-fallback.md): dependency
+discovery goes system-packages-first with a CPM source-build fallback. On
+Linux (Nix shell, cached CI prefix) nothing changes; on Windows — where no
+SDL3 packages or pkg-config exist — SDL 3.4.12 and SDL3_image 3.2.4 build
+from source automatically, pinned to the same versions as everywhere else.
+`-DRAVEN_BUNDLED_DEPS=ON` forces the source path for testing it on Linux.
+
+Windows-specific fixes that came with it:
+
+- Assets **copy** next to the binary instead of symlinking (symlinks need
+  developer mode on Windows); `$<TARGET_RUNTIME_DLLS>` post-build steps put
+  SDL3.dll beside both the game and the test runner.
+- MSVC gets `/W4 /permissive- /Zc:__cplusplus` — and crucially `/utf-8`,
+  because the sources contain UTF-8 punctuation that MSVC misparses under a
+  system codepage.
+- CI grew a `windows-latest` job: MSVC, bundled deps, full test suite with
+  dummy video/audio drivers.
+
+## Steamworks
+
+[ADR-0021](../decisions/0021-optional-steamworks.md): the SDK is
+NDA-distributed and cannot live in the repo, so integration is an opt-in
+flag with a no-op fallback. `-DRAVEN_ENABLE_STEAM=ON` +
+`vendor/steamworks/sdk` links the redistributable and defines
+`RAVEN_ENABLE_STEAM`; without it, the `Steam` wrapper
+(`src/platform/steam.hpp`) compiles to no-ops and `is_active()` stays
+false — no ifdefs at call sites. `Game` inits it after SDL, pumps
+`SteamAPI_RunCallbacks` each frame, and shuts down before `SDL_Quit`.
+Runtime failure (Steam not running, no dev `steam_appid.txt`) logs a
+warning and the game continues standalone.
+
+The real-SDK path was compile-and-link verified against a minimal local
+mock of the API surface (the flag, the SDK finder, the redistributable
+copy, the graceful init failure). True end-to-end verification waits on a
+partner account and app id.
+
+## Verification
+
+- Linux system-SDL build: unchanged, 102/102 tests
+- `RAVEN_BUNDLED_DEPS=ON` on Linux: SDL builds from source via CPM,
+  102/102 tests — the same resolution path Windows CI takes
+- `RAVEN_ENABLE_STEAM=ON` without the SDK: clear fatal error with setup
+  instructions; with the mock SDK: builds, links, copies the
+  redistributable, and degrades gracefully at runtime
+- Windows CI job: validated on this branch before merging

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -36,6 +36,10 @@ bool Game::init() {
     audio_.init();
     audio_.set_master_gain(static_cast<float>(settings_.sfx_volume) / 100.f);
 
+    // Steam is optional: no-op unless built with RAVEN_ENABLE_STEAM and
+    // running under Steam (or with a dev steam_appid.txt)
+    steam_.init();
+
 #ifdef RAVEN_ENABLE_IMGUI
     debug_overlay_.init(renderer_.sdl_window(), renderer_.sdl_renderer());
 #endif
@@ -157,6 +161,9 @@ void Game::run() {
         // Reap finished sound effect streams
         audio_.update();
 
+        // Pump Steam callbacks (no-op when inactive)
+        steam_.run_callbacks();
+
         // Render
         render();
 
@@ -217,6 +224,7 @@ void Game::shutdown() {
     font_ = BitmapFont{};
     renderer_.shutdown();
     audio_.shutdown();
+    steam_.shutdown();
     input_.shutdown(); // close gamepad before SDL_Quit
 
     SDL_Quit();

--- a/src/core/game.hpp
+++ b/src/core/game.hpp
@@ -4,6 +4,7 @@
 #include "core/clock.hpp"
 #include "core/input.hpp"
 #include "core/settings.hpp"
+#include "platform/steam.hpp"
 #include "rendering/bitmap_font.hpp"
 #include "rendering/renderer.hpp"
 #include "rendering/sprite_sheet.hpp"
@@ -79,6 +80,10 @@ class Game {
     /// @return Mutable reference to the AudioEngine (no-op when silent).
     AudioEngine& audio() { return audio_; }
 
+    /// @brief Access the Steamworks integration (no-op without the SDK).
+    /// @return Mutable reference to the Steam wrapper.
+    Steam& steam() { return steam_; }
+
     /// @brief Access the UI bitmap font.
     /// @return Const reference to the BitmapFont (may be unloaded; draws no-op).
     [[nodiscard]] const BitmapFont& font() const { return font_; }
@@ -98,6 +103,7 @@ class Game {
     Settings settings_;
     BitmapFont font_;
     AudioEngine audio_;
+    Steam steam_;
     std::string settings_path_; ///< Full path to the user settings file.
 
 #ifdef RAVEN_ENABLE_IMGUI

--- a/src/platform/steam.cpp
+++ b/src/platform/steam.cpp
@@ -1,0 +1,45 @@
+#include "platform/steam.hpp"
+
+#include <spdlog/spdlog.h>
+
+#ifdef RAVEN_ENABLE_STEAM
+#include <steam/steam_api.h>
+#endif
+
+namespace raven {
+
+bool Steam::init() {
+#ifdef RAVEN_ENABLE_STEAM
+    if (!SteamAPI_Init()) {
+        spdlog::warn("SteamAPI_Init failed (is Steam running, and is "
+                     "steam_appid.txt present for dev builds?) — running without Steam");
+        return false;
+    }
+    active_ = true;
+    spdlog::info("Steamworks initialised");
+    return true;
+#else
+    spdlog::debug("Built without Steamworks support");
+    return false;
+#endif
+}
+
+void Steam::shutdown() {
+#ifdef RAVEN_ENABLE_STEAM
+    if (active_) {
+        SteamAPI_Shutdown();
+        active_ = false;
+        spdlog::info("Steamworks shut down");
+    }
+#endif
+}
+
+void Steam::run_callbacks() {
+#ifdef RAVEN_ENABLE_STEAM
+    if (active_) {
+        SteamAPI_RunCallbacks();
+    }
+#endif
+}
+
+} // namespace raven

--- a/src/platform/steam.hpp
+++ b/src/platform/steam.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace raven {
+
+/// @brief Optional Steamworks integration.
+///
+/// Compiled in only when RAVEN_ENABLE_STEAM is set (requires the
+/// Steamworks SDK under vendor/steamworks/sdk — see cmake/Steamworks.cmake).
+/// Without it, every method is a no-op and is_active() stays false, so
+/// call sites never need #ifdefs. Failure to attach to Steam at runtime
+/// (SDK present but Steam not running) is also non-fatal: the game runs
+/// without Steam features.
+class Steam {
+  public:
+    /// @brief Attach to Steam if built with Steamworks support.
+    ///
+    /// During development this requires a steam_appid.txt next to the
+    /// binary (not shipped); under a Steam launch it attaches directly.
+    /// @return True if the Steam API initialised.
+    bool init();
+
+    /// @brief Detach from Steam. Safe to call when inactive.
+    void shutdown();
+
+    /// @brief Pump Steam callbacks. Call once per frame; no-op when inactive.
+    void run_callbacks();
+
+    /// @brief Whether the Steam API is attached and callbacks are live.
+    /// @return True between a successful init() and shutdown().
+    [[nodiscard]] bool is_active() const { return active_; }
+
+  private:
+    bool active_ = false;
+};
+
+} // namespace raven

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,4 +53,14 @@ target_link_libraries(raven_tests PRIVATE
     SDL3_image::SDL3_image
 )
 
+# Shared dependencies (SDL3.dll, ...) must sit next to the test binary
+if(WIN32)
+    add_custom_command(TARGET raven_tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_RUNTIME_DLLS:raven_tests> $<TARGET_FILE_DIR:raven_tests>
+        COMMAND_EXPAND_LISTS
+        COMMENT "Copying runtime DLLs for tests"
+    )
+endif()
+
 catch_discover_tests(raven_tests)

--- a/tests/test_patterns.cpp
+++ b/tests/test_patterns.cpp
@@ -7,6 +7,11 @@
 
 using namespace raven;
 
+namespace {
+// M_PI is not portable (MSVC needs _USE_MATH_DEFINES); match the game code
+constexpr float PI = 3.14159265358979323846f;
+} // namespace
+
 // Test bullet pattern math
 TEST_CASE("Radial pattern angle distribution", "[patterns]") {
     SECTION("3-way spread in 360 degrees") {
@@ -47,7 +52,7 @@ TEST_CASE("Bullet velocity from angle and speed", "[patterns]") {
     }
 
     SECTION("90 degrees = down") {
-        float angle_rad = static_cast<float>(M_PI) / 2.f;
+        float angle_rad = PI / 2.f;
         float vx = std::cos(angle_rad) * speed;
         float vy = std::sin(angle_rad) * speed;
         REQUIRE(vx == Catch::Approx(0.f).margin(0.001f));


### PR DESCRIPTION
Raven now builds and passes its full test suite on Windows, and has the Steamworks integration point ready for when a partner account exists. These were the last two platform items from the Steam-readiness review.

## Windows/MSVC support (`9fa77ec`, ADR-0020)

**Dependency fallback**: discovery is system-packages-first (Nix shell and the cached Linux CI prefix are unchanged), with a CPM source-build fallback for SDL 3.4.12 / SDL3_image 3.2.4 when no packages exist — which is every Windows machine. `-DRAVEN_BUNDLED_DEPS=ON` forces the source path; `cmake -B build` now works on a bare Windows box with only Visual Studio installed.

Riding along:
- Assets **copy** next to the binary on Windows instead of symlinking (symlinks need developer mode); `$<TARGET_RUNTIME_DLLS>` post-build steps deploy SDL3.dll beside both the game and the test runner
- MSVC warning flags: `/W4 /permissive- /Zc:__cplusplus` and — essential — `/utf-8` (sources contain UTF-8 punctuation MSVC misreads under a system codepage)
- New `build-test-windows` CI job: MSVC, bundled deps, full ctest with dummy video/audio drivers

## Optional Steamworks (`462009a`, ADR-0021)

The SDK is NDA-distributed and can't live in the repo, so integration is opt-in with a no-op fallback:
- `-DRAVEN_ENABLE_STEAM=ON` expects the SDK at `vendor/steamworks/sdk` (clear fatal error with setup instructions otherwise), links the per-platform redistributable, and copies it next to the binary
- `src/platform/steam.hpp` is a thin wrapper (`init` / `run_callbacks` / `shutdown` / `is_active`) — every method compiles to a no-op without the flag, so call sites carry zero ifdefs
- Runtime failure (Steam not running, no dev `steam_appid.txt`) logs a warning and the game continues standalone — same degradation philosophy as audio/fonts/sprites
- `Game` inits it after SDL, pumps callbacks once per frame, shuts down before `SDL_Quit`

## Portability fix (`718ce5c`)

The only compile error in the entire Windows port was one `M_PI` in a test file (MSVC needs `_USE_MATH_DEFINES`); replaced with the local `PI` constant pattern the game code already uses.

## Verification

- **CI fully green including the new Windows job**: [run #9](https://github.com/adanoelle/raven/actions/runs/28799540742) — Raven built under MSVC and passed all **102 tests on Windows** for the first time
- Linux system-SDL path: unchanged, 102/102
- `RAVEN_BUNDLED_DEPS=ON` exercised on Linux: SDL source-builds via CPM, 102/102
- `RAVEN_ENABLE_STEAM=ON` without SDK: clear fatal error; with a local mock SDK: builds, links, deploys the redistributable, and degrades gracefully at runtime (real-SDK verification waits on a partner account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiNf1uVLdvAesmET4ynY3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiNf1uVLdvAesmET4ynY3a)_