### PR TITLE
refactor: apply architecture review fixes for audio, rendering, and settings

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -73,6 +73,7 @@
 - [SDL3 Migration](devlog/2026-02-12-sdl3-migration.md)
 - [Steam Readiness Sprint](devlog/2026-07-03-steam-readiness-sprint.md)
 - [Options Menu and Sound Effects](devlog/2026-07-05-options-and-audio.md)
+- [Architecture Review and Follow-up Fixes](devlog/2026-07-15-architecture-review-fixes.md)
 
 ---
 

--- a/docs/book/src/devlog/2026-07-15-architecture-review-fixes.md
+++ b/docs/book/src/devlog/2026-07-15-architecture-review-fixes.md
@@ -1,0 +1,75 @@
+# Architecture Review and Follow-up Fixes
+
+Date: 2026-07-15 Tags: review, performance, audio, rendering, settings
+
+## The Review
+
+With Steam and (eventually) Nintendo as targets, the whole stack got a
+design review: EnTT, SDL3, the no-engine decision, the fixed 120 Hz
+timestep, and the dependency set.
+
+**The verdict on the big choices: keep all of them.**
+
+- **EnTT** is used idiomatically (free-function systems over views, POD
+  components, registry-context singletons) and is console-proven. Nothing
+  at this entity count challenges it.
+- **SDL3** with `SDL_Renderer`, logical presentation, and
+  `SDL_SCALEMODE_PIXELART` is the right abstraction height for 480x270
+  pixel art — no direct graphics API use is what makes a console port
+  tractable. NDA'd console ports of SDL exist for registered developers,
+  so the Switch story is real. Watch-item: the SDL 3.4 floor is
+  bleeding-edge; console SDK ports lag, so a `SDL_SCALEMODE_NEAREST`
+  fallback is cheap insurance. SDL3_image is the one system (pkg-config)
+  dependency — vendoring or replacing it would simplify cross-builds.
+- **Native SDL3 audio** (ADR-0019) turned out better than the reviewer's
+  own initial suggestion of SDL3_mixer: every dependency we don't have is
+  one less port to line up.
+- **The `AudioQueue` seam** (systems push enum events; the scene drains
+  to the engine) keeps gameplay systems pure and testable and is the
+  pattern to repeat for future engine-facing effects.
+
+## What the Review Found
+
+Ordered by impact; all fixed in this change unless noted:
+
+1. **Same-tick SFX stacking.** N copies of one effect in a single tick
+   played sample-aligned and summed to N-times amplitude — a distorted pop
+   whenever a multi-pellet burst connected. The drain in `GameScene` now
+   dedupes effects per tick with a bitmask.
+2. **Unbounded audio voices.** Each `play()` binds a new stream with no
+   cap. `AudioEngine` now enforces `MAX_VOICES` (32): it reaps finished
+   streams first and drops the play if still saturated.
+3. **String round-trips in hot paths.** The render loop resolved each
+   sprite's interned `StringId` back to a `std::string` and did a
+   string-keyed hash lookup per sprite per frame (same pattern per emitter
+   per tick in the emitter/melee systems). `SpriteSheetManager` and
+   `PatternLibrary` are now keyed by `StringId` directly; the string
+   overloads remain as cold-path/test conveniences.
+4. **Unstable sprite sort.** `std::sort` by layer only let equal-layer
+   sprites swap draw order between frames (z-flicker) because view
+   iteration order changes as entities churn. Now `std::stable_sort` by
+   (layer, y) — which also gives top-down depth within a layer.
+5. **Settings written on every slider step.** Dragging a volume slider
+   wrote `settings.json` ten times. `apply_settings()` no longer persists;
+   `OptionsScene::on_exit` saves once. Batching writes matters more on
+   console save-data backends than on PC.
+6. **Linear volume slider.** Perceived loudness is roughly logarithmic;
+   volume now maps through a quadratic curve so the slider feels even.
+7. **Interner overflow.** `StringInterner::intern` silently wrapped its
+   `uint16_t` index past 65,535 strings, aliasing two strings to one ID.
+   Now asserts in debug and returns the invalid sentinel in release.
+
+## Still Open (tracked, not fixed here)
+
+- **Bullet owner tags** (`PlayerBullet`/`EnemyBullet` instead of an enum
+  filter) so collision views only touch their own population. No spatial
+  broadphase until profiling asks for it.
+- **Room transitions re-parse the LDtk file from disk**; cache the parsed
+  project when maps grow.
+- **SFX for GroundSlam and ConcussionShot** — the two active abilities
+  are silent while dash/melee are not.
+- **RNG distribution portability** — `std::uniform_real_distribution` is
+  implementation-defined; hand-roll it if seeded runs/replays land.
+- **Menu navigation is triplicated** across title/pause/options scenes;
+  extract a cursor helper next time a menu is touched.
+- Vendor or replace SDL3_image; `SDL_SCALEMODE_NEAREST` fallback.

--- a/src/audio/audio_engine.cpp
+++ b/src/audio/audio_engine.cpp
@@ -77,6 +77,17 @@ void AudioEngine::play(const std::string& id, float gain) {
     }
     const Sound& sound = it->second;
 
+    // Voice limit: reap finished streams first, then drop the play if the
+    // cap is still hit. Bounds stream count during bullet-hell bursts —
+    // past ~this many overlapping effects the new one is inaudible anyway.
+    if (streams_.size() >= MAX_VOICES) {
+        update();
+        if (streams_.size() >= MAX_VOICES) {
+            spdlog::debug("Voice cap reached, dropping '{}'", id);
+            return;
+        }
+    }
+
     // One stream per playing instance; SDL mixes all streams bound to the
     // device. The stream converts from the WAV format to the device format.
     SDL_AudioStream* stream = SDL_CreateAudioStream(&sound.spec, nullptr);

--- a/src/audio/audio_engine.hpp
+++ b/src/audio/audio_engine.hpp
@@ -20,6 +20,9 @@ namespace raven {
 /// audio device plays silently rather than crashing).
 class AudioEngine {
   public:
+    /// @brief Maximum simultaneously playing streams; further plays drop.
+    static constexpr size_t MAX_VOICES = 32;
+
     AudioEngine() = default;
     ~AudioEngine();
 
@@ -48,6 +51,9 @@ class AudioEngine {
     void update();
 
     /// @brief Set the master volume applied to all subsequent plays.
+    ///
+    /// Already-playing streams keep the gain they started with — fine for
+    /// sub-second effects, but a future music stream must be updated live.
     /// @param gain Linear gain, 0.0 (silent) to 1.0 (full).
     void set_master_gain(float gain);
 

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -12,6 +12,19 @@
 
 namespace raven {
 
+namespace {
+
+/// @brief Map a 0-100 volume setting to a linear gain, perceptually curved.
+///
+/// Loudness perception is roughly logarithmic; a quadratic curve keeps the
+/// slider feeling even instead of bunching audible change at the low end.
+float volume_to_gain(int volume) {
+    const float v = static_cast<float>(volume) / 100.f;
+    return v * v;
+}
+
+} // anonymous namespace
+
 Game::Game() = default;
 Game::~Game() = default;
 
@@ -34,22 +47,23 @@ bool Game::init() {
 
     // Audio is optional: a failed init leaves the engine in silent no-op mode
     audio_.init();
-    audio_.set_master_gain(static_cast<float>(settings_.sfx_volume) / 100.f);
+    audio_.set_master_gain(volume_to_gain(settings_.sfx_volume));
 
 #ifdef RAVEN_ENABLE_IMGUI
     debug_overlay_.init(renderer_.sdl_window(), renderer_.sdl_renderer());
 #endif
 
-    if (!load_assets()) {
-        return false;
-    }
-
-    // Pre-intern known sprite sheet IDs
+    // The interner must exist before load_assets(): sprite sheets are
+    // registered under interned IDs.
     auto& interner = registry_.ctx().emplace<StringInterner>();
     interner.intern("player");
     interner.intern("enemies");
     interner.intern("projectiles");
     interner.intern("pickups");
+
+    if (!load_assets()) {
+        return false;
+    }
 
     // Start with title scene
     scenes_.push(std::make_unique<TitleScene>(), *this);
@@ -86,12 +100,14 @@ bool Game::load_assets() {
         }
 
         if (config.contains("sprite_sheets")) {
+            auto& interner = registry_.ctx().get<StringInterner>();
             for (const auto& sheet : config["sprite_sheets"]) {
                 auto id = sheet.at("id").get<std::string>();
                 auto path = sheet.at("path").get<std::string>();
                 int fw = sheet.at("frame_w").get<int>();
                 int fh = sheet.at("frame_h").get<int>();
-                if (!sprites_.load(renderer_.sdl_renderer(), id, paths::asset(path), fw, fh)) {
+                if (!sprites_.load(renderer_.sdl_renderer(), interner.intern(id),
+                                   paths::asset(path), fw, fh)) {
                     spdlog::warn("Failed to load sprite sheet '{}'", id);
                 }
             }
@@ -188,7 +204,10 @@ void Game::apply_settings() {
         renderer_.set_window_scale(settings_.window_scale);
     }
     renderer_.set_vsync(settings_.vsync);
-    audio_.set_master_gain(static_cast<float>(settings_.sfx_volume) / 100.f);
+    audio_.set_master_gain(volume_to_gain(settings_.sfx_volume));
+}
+
+void Game::save_settings() {
     settings_.save(settings_path_);
 }
 

--- a/src/core/game.hpp
+++ b/src/core/game.hpp
@@ -69,11 +69,15 @@ class Game {
     /// @return Mutable reference to the Settings.
     [[nodiscard]] Settings& settings_mut() { return settings_; }
 
-    /// @brief Apply the current settings to subsystems and save them.
+    /// @brief Apply the current settings to subsystems (does not persist).
     ///
-    /// Pushes fullscreen/scale/vsync to the renderer, volume to the audio
-    /// engine, and writes settings.json to the pref dir.
+    /// Pushes fullscreen/scale/vsync to the renderer and volume to the
+    /// audio engine. Call save_settings() to persist — callers that adjust
+    /// repeatedly (option sliders) apply per change and save once on exit.
     void apply_settings();
+
+    /// @brief Write the current settings to settings.json in the pref dir.
+    void save_settings();
 
     /// @brief Access the sound effect engine.
     /// @return Mutable reference to the AudioEngine (no-op when silent).

--- a/src/core/string_id.hpp
+++ b/src/core/string_id.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -36,10 +37,24 @@ class StringInterner {
         if (it != map_.end()) {
             return it->second;
         }
+        // uint16_t index space is the hard capacity; wrapping silently
+        // would alias two strings to one ID.
+        assert(strings_.size() <= UINT16_MAX && "StringInterner capacity exhausted");
+        if (strings_.size() > UINT16_MAX) {
+            return StringId{}; // invalid sentinel in release builds
+        }
         auto id = StringId{static_cast<uint16_t>(strings_.size())};
         strings_.push_back(str);
         map_.emplace(str, id);
         return id;
+    }
+
+    /// @brief Look up a string's StringId without interning it.
+    /// @param str The string to look up.
+    /// @return The existing StringId, or the invalid sentinel if not interned.
+    [[nodiscard]] StringId find(const std::string& str) const {
+        auto it = map_.find(str);
+        return it != map_.end() ? it->second : StringId{};
     }
 
     /// @brief Resolve a StringId back to its original string.

--- a/src/ecs/systems/emitter_system.cpp
+++ b/src/ecs/systems/emitter_system.cpp
@@ -66,8 +66,6 @@ void fire_burst(entt::registry& reg, const EmitterDef& emitter, float center_ang
 } // anonymous namespace
 
 void update_emitters(entt::registry& reg, const PatternLibrary& patterns, float dt) {
-    const auto& interner = reg.ctx().get<StringInterner>();
-
     float player_x = 0.f;
     float player_y = 0.f;
     bool has_player = find_player_position(reg, player_x, player_y);
@@ -78,7 +76,7 @@ void update_emitters(entt::registry& reg, const PatternLibrary& patterns, float 
             continue;
         }
 
-        const auto* pattern = patterns.get(interner.resolve(emitter.pattern_name));
+        const auto* pattern = patterns.get(emitter.pattern_name);
         if (!pattern) {
             continue;
         }

--- a/src/ecs/systems/melee_system.cpp
+++ b/src/ecs/systems/melee_system.cpp
@@ -95,7 +95,7 @@ void update_melee(entt::registry& reg, const InputState& input, const PatternLib
                 if (auto* emitter = reg.try_get<BulletEmitter>(hit.ent)) {
                     auto* e_tf = reg.try_get<Transform2D>(hit.ent);
                     if (e_tf && emitter->pattern_name.valid()) {
-                        const auto* pattern = patterns.get(interner.resolve(emitter->pattern_name));
+                        const auto* pattern = patterns.get(emitter->pattern_name);
                         if (pattern && !pattern->emitters.empty()) {
                             auto pickup_ent = reg.create();
                             reg.emplace<Transform2D>(pickup_ent, e_tf->x, e_tf->y);

--- a/src/ecs/systems/render_system.cpp
+++ b/src/ecs/systems/render_system.cpp
@@ -24,8 +24,6 @@ namespace raven::systems {
 
 void render_sprites(entt::registry& reg, SDL_Renderer* renderer, const SpriteSheetManager& sprites,
                     float interpolation_alpha) {
-    const auto& interner = reg.ctx().get<StringInterner>();
-
     // Persistent scratch buffer — cleared each frame, capacity stays allocated
     auto& entries = reg.ctx().emplace<std::vector<RenderEntry>>();
     entries.clear();
@@ -40,7 +38,7 @@ void render_sprites(entt::registry& reg, SDL_Renderer* renderer, const SpriteShe
             render_y = prev->y + (tf.y - prev->y) * interpolation_alpha;
         }
 
-        const auto* sheet = sprites.get(interner.resolve(sprite.sheet_id));
+        const auto* sheet = sprites.get(sprite.sheet_id);
         if (!sheet) {
             // No sprite sheet loaded — draw a placeholder colored rect
             SDL_FRect rect{render_x + sprite.offset_x - static_cast<float>(sprite.width) / 2.f,
@@ -67,9 +65,17 @@ void render_sprites(entt::registry& reg, SDL_Renderer* renderer, const SpriteShe
                            sprite.offset_y, sheet});
     }
 
-    // Sort by layer (lower layers drawn first)
-    std::sort(entries.begin(), entries.end(),
-              [](const RenderEntry& a, const RenderEntry& b) { return a.layer < b.layer; });
+    // Sort by layer, then y for top-down depth within a layer. Stable so
+    // exact ties keep a consistent order across frames — view iteration
+    // order changes as entities churn, and std::sort would let equal
+    // sprites swap draw order frame-to-frame (z-flicker).
+    std::stable_sort(entries.begin(), entries.end(),
+                     [](const RenderEntry& a, const RenderEntry& b) {
+                         if (a.layer != b.layer) {
+                             return a.layer < b.layer;
+                         }
+                         return a.y < b.y;
+                     });
 
     // Draw
     for (const auto& e : entries) {

--- a/src/patterns/pattern_library.cpp
+++ b/src/patterns/pattern_library.cpp
@@ -68,7 +68,7 @@ bool PatternLibrary::load_file(const std::string& file_path) {
         auto j = nlohmann::json::parse(f);
         auto pattern = parse_pattern(j);
         auto name = pattern.name;
-        patterns_[name] = std::move(pattern);
+        patterns_[interner_->intern(name).value] = std::move(pattern);
         spdlog::debug("Loaded pattern '{}'", name);
         return true;
     } catch (const nlohmann::json::exception& e) {
@@ -85,7 +85,7 @@ bool PatternLibrary::load_from_json(const nlohmann::json& j) {
     try {
         auto pattern = parse_pattern(j);
         auto name = pattern.name;
-        patterns_[name] = std::move(pattern);
+        patterns_[interner_->intern(name).value] = std::move(pattern);
         spdlog::debug("Loaded pattern '{}' from JSON", name);
         return true;
     } catch (const nlohmann::json::exception& e) {
@@ -94,16 +94,26 @@ bool PatternLibrary::load_from_json(const nlohmann::json& j) {
     }
 }
 
-const PatternDef* PatternLibrary::get(const std::string& name) const {
-    auto it = patterns_.find(name);
+const PatternDef* PatternLibrary::get(StringId id) const {
+    if (!id.valid()) {
+        return nullptr;
+    }
+    auto it = patterns_.find(id.value);
     return it != patterns_.end() ? &it->second : nullptr;
+}
+
+const PatternDef* PatternLibrary::get(const std::string& name) const {
+    if (!interner_) {
+        return nullptr;
+    }
+    return get(interner_->find(name));
 }
 
 std::vector<std::string> PatternLibrary::names() const {
     std::vector<std::string> result;
     result.reserve(patterns_.size());
-    for (const auto& [name, _] : patterns_) {
-        result.push_back(name);
+    for (const auto& [id, def] : patterns_) {
+        result.push_back(def.name);
     }
     return result;
 }

--- a/src/patterns/pattern_library.hpp
+++ b/src/patterns/pattern_library.hpp
@@ -64,7 +64,12 @@ class PatternLibrary {
     /// @return True on success, false if the JSON structure is invalid.
     bool load_from_json(const nlohmann::json& j);
 
-    /// @brief Retrieve a pattern by name.
+    /// @brief Retrieve a pattern by interned ID (hot path — integer lookup).
+    /// @param id The interned pattern name, e.g. BulletEmitter::pattern_name.
+    /// @return Pointer to the PatternDef, or nullptr if not found.
+    [[nodiscard]] const PatternDef* get(StringId id) const;
+
+    /// @brief Retrieve a pattern by name (cold path — hashes the string).
     /// @param name The pattern identifier.
     /// @return Pointer to the PatternDef, or nullptr if not found.
     [[nodiscard]] const PatternDef* get(const std::string& name) const;
@@ -78,7 +83,7 @@ class PatternLibrary {
     void set_interner(StringInterner& interner) { interner_ = &interner; }
 
   private:
-    std::unordered_map<std::string, PatternDef> patterns_;
+    std::unordered_map<uint16_t, PatternDef> patterns_; ///< Keyed by interned name.
     StringInterner* interner_ = nullptr;
 
     PatternDef parse_pattern(const nlohmann::json& j) const;

--- a/src/rendering/sprite_sheet.cpp
+++ b/src/rendering/sprite_sheet.cpp
@@ -63,18 +63,21 @@ void SpriteSheet::draw(SDL_Renderer* renderer, int frame_x, int frame_y, int des
 
 // ── SpriteSheetManager ───────────────────────────────────────────
 
-bool SpriteSheetManager::load(SDL_Renderer* renderer, const std::string& id,
-                              const std::string& path, int frame_w, int frame_h) {
+bool SpriteSheetManager::load(SDL_Renderer* renderer, StringId id, const std::string& path,
+                              int frame_w, int frame_h) {
+    if (!id.valid()) {
+        return false;
+    }
     auto sheet = std::make_unique<SpriteSheet>();
     if (!sheet->load(renderer, path, frame_w, frame_h)) {
         return false;
     }
-    sheets_[id] = std::move(sheet);
+    sheets_[id.value] = std::move(sheet);
     return true;
 }
 
-const SpriteSheet* SpriteSheetManager::get(const std::string& id) const {
-    auto it = sheets_.find(id);
+const SpriteSheet* SpriteSheetManager::get(StringId id) const {
+    auto it = sheets_.find(id.value);
     return it != sheets_.end() ? it->second.get() : nullptr;
 }
 

--- a/src/rendering/sprite_sheet.hpp
+++ b/src/rendering/sprite_sheet.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/string_id.hpp"
+
 #include <SDL3/SDL.h>
 
 #include <memory>
@@ -63,26 +65,29 @@ class SpriteSheet {
     int sheet_h_ = 0;
 };
 
-/// @brief Registry of named sprite sheets. Owns all loaded SpriteSheet instances.
+/// @brief Registry of sprite sheets keyed by interned StringId.
+///
+/// Keyed by StringId rather than string so the render hot path does an
+/// integer map lookup per sprite instead of a string hash.
 class SpriteSheetManager {
   public:
-    /// @brief Load a sprite sheet and register it under a string ID.
+    /// @brief Load a sprite sheet and register it under an interned ID.
     /// @param renderer SDL_Renderer used to create the texture.
-    /// @param id Unique identifier for later retrieval.
+    /// @param id Interned identifier for later retrieval (must be valid).
     /// @param path File path to the PNG image.
     /// @param frame_w Width of a single frame in pixels.
     /// @param frame_h Height of a single frame in pixels.
-    /// @return True on success, false if loading failed.
-    bool load(SDL_Renderer* renderer, const std::string& id, const std::string& path, int frame_w,
+    /// @return True on success, false if loading failed or id is invalid.
+    bool load(SDL_Renderer* renderer, StringId id, const std::string& path, int frame_w,
               int frame_h);
 
     /// @brief Retrieve a loaded sprite sheet by ID.
     /// @param id The identifier used when the sheet was loaded.
     /// @return Pointer to the SpriteSheet, or nullptr if not found.
-    [[nodiscard]] const SpriteSheet* get(const std::string& id) const;
+    [[nodiscard]] const SpriteSheet* get(StringId id) const;
 
   private:
-    std::unordered_map<std::string, std::unique_ptr<SpriteSheet>> sheets_;
+    std::unordered_map<uint16_t, std::unique_ptr<SpriteSheet>> sheets_;
 };
 
 } // namespace raven

--- a/src/scenes/game_scene.cpp
+++ b/src/scenes/game_scene.cpp
@@ -283,9 +283,18 @@ void GameScene::update(Game& game, float dt) {
         systems::update_waves(reg, tilemap_, *stage, pattern_lib_);
     }
 
-    // Forward sound requests pushed by the systems above to the engine
+    // Forward sound requests pushed by the systems above to the engine.
+    // Dedupe per tick: N same-tick copies of one effect play sample-aligned
+    // and sum to N-times amplitude (a distorted pop, not a louder hit) —
+    // e.g. one shotgun burst hitting five enemies at once.
     if (auto* audio_queue = reg.ctx().find<AudioQueue>()) {
+        uint32_t played_mask = 0;
         for (Sfx sfx : audio_queue->events) {
+            const uint32_t bit = 1u << static_cast<uint32_t>(sfx);
+            if (played_mask & bit) {
+                continue;
+            }
+            played_mask |= bit;
             game.audio().play(sfx_sound_name(sfx));
         }
         audio_queue->events.clear();

--- a/src/scenes/options_scene.cpp
+++ b/src/scenes/options_scene.cpp
@@ -39,6 +39,13 @@ void OptionsScene::on_enter(Game& /*game*/) {
     spdlog::info("Entered options scene");
 }
 
+void OptionsScene::on_exit(Game& game) {
+    // Persist once here instead of on every adjustment: sliders generate a
+    // write per input edge, and batching writes is kinder to save-data
+    // backends (notably consoles).
+    game.save_settings();
+}
+
 void OptionsScene::adjust(Game& game, int direction) {
     auto& s = game.settings_mut();
 

--- a/src/scenes/options_scene.hpp
+++ b/src/scenes/options_scene.hpp
@@ -8,13 +8,15 @@ namespace raven {
 ///
 /// Pushed from the title screen or the pause menu; renders over whatever
 /// is beneath it (own dim layer, no clear). Up/down selects a setting,
-/// left/right adjusts it, and every change is applied live and persisted
-/// via Game::apply_settings(). Cancel or Back pops the scene.
+/// left/right adjusts it, and every change is applied live via
+/// Game::apply_settings(); settings.json is written once when the scene
+/// exits rather than on every adjustment. Cancel or Back pops the scene.
 ///
 /// Items: fullscreen, window scale, vsync, music volume, sfx volume, back.
 class OptionsScene : public Scene {
   public:
     void on_enter(Game& game) override;
+    void on_exit(Game& game) override;
     void update(Game& game, float dt) override;
     void render(Game& game) override;
 


### PR DESCRIPTION
## Summary

Applies the fixes from the 2026-07-15 architecture review (EnTT / SDL3 / no-engine stack review plus a follow-up pass on the audio and options merges), and records the review's verdict and open items as a devlog entry.

### Audio
- **Dedupe same-tick sound effects** in the `GameScene` drain. N copies of one effect in a single tick play sample-aligned and sum to N× amplitude — a distorted pop whenever a multi-bullet burst connects. A per-tick bitmask now plays each effect once.
- **Voice cap** (`AudioEngine::MAX_VOICES` = 32): `play()` reaps finished streams first, then drops the play if still saturated, bounding stream growth during bullet-hell bursts.

### Rendering / hot paths
- **`SpriteSheetManager` and `PatternLibrary` are now keyed by `StringId`.** The render loop was resolving each sprite's interned ID back to a `std::string` and doing a string-keyed hash lookup per sprite per frame (same pattern per emitter per tick). Hot paths now do integer map lookups; the string overload of `PatternLibrary::get()` remains as a cold-path/test convenience via a new non-mutating `StringInterner::find()`.
- **Stable sprite sort**: `std::stable_sort` by (layer, y) replaces `std::sort` by layer only — equal-layer sprites could swap draw order between frames as view iteration order churned (z-flicker). The y tiebreaker also gives top-down depth within a layer.

### Settings
- **Persist once on options-scene exit** instead of writing `settings.json` on every slider step. `Game::apply_settings()` now only pushes state to subsystems; new `Game::save_settings()` does the write.
- **Perceptual volume curve**: 0–100 sliders map through a quadratic so the slider feels even (loudness perception is roughly logarithmic).

### Robustness
- **`StringInterner::intern` overflow guard**: asserts in debug and returns the invalid sentinel in release instead of silently wrapping the `uint16_t` index and aliasing two strings to one ID.

### Docs
- Devlog entry `2026-07-15-architecture-review-fixes.md` summarizing the review verdict (keep EnTT, SDL3, native-SDL3 audio, no-engine) and the still-open items (bullet owner tags, LDtk project caching, GroundSlam/ConcussionShot SFX, portable RNG distribution, menu-cursor extraction, SDL3_image vendoring).

## Test plan

- Built Debug with Ninja against SDL 3.4.12 / SDL_image 3.2.4 (same versions as CI) and ran the full suite: **102/102 tests pass** (`SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy`).
- `clang-format` run on all changed files.
- Existing tests cover the changed pattern/emitter/melee paths (string-keyed `get()` is exercised by `test_pickups`/`test_patterns`; the `StringId` path by `test_emitters`); audio queue behavior covered by `test_audio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zEvXzNYYhwGoYaMkjZQT9

---
_Generated by [Claude Code](https://claude.ai/code/session_014zEvXzNYYhwGoYaMkjZQT9)_