### PR TITLE
docs: update art spec for 24x24 grunt tier

### DIFF
--- a/docs/book/src/art/art-aseprite-guide.md
+++ b/docs/book/src/art/art-aseprite-guide.md
@@ -15,7 +15,7 @@ needing a separate overlay system.
 
 | Tier        | Frame Size | Body Size | Padding      | Used For                            |
 | ----------- | ---------- | --------- | ------------ | ----------------------------------- |
-| Small       | 16x16      | 14x14     | 1px per side | Grunt enemies, small pickups        |
+| Small       | 24x24      | 20x20     | 2px per side | Grunt enemies                       |
 | Medium      | 32x32      | 24x24     | 4px per side | Player characters, mid-tier enemies |
 | Large       | 48x48      | 36x36     | 6px per side | Bosses                              |
 | Extra-large | 64x64      | 48x48     | 8px per side | Mega-bosses, special encounters     |
@@ -59,29 +59,31 @@ or boss at that size.
 
 ### 2.2 Guide placement for each tier
 
-#### Small (16x16 frame, 14x14 body)
+#### Small (24x24 frame, 20x20 body)
 
 ```
-Guides: x=1, x=15, y=1, y=15 (body zone)
-Center: x=8, y=8
+Guides: x=2, x=22, y=2, y=22 (body zone)
+Center: x=12, y=12
 ```
 
 ```
-  0               15
-  ┌────────────────┐
-  │░░░░░░░░░░░░░░░░│ 0
-  │░┌────────────┐░│ 1  ← body top
-  │░│            │░│
-  │░│   14x14    │░│
-  │░│   body     │░│    ← x=8 center
-  │░│            │░│
-  │░│            │░│
-  │░└────────────┘░│ 15 ← body bottom
-  └────────────────┘
-    1              15
+  0                       23
+  ┌────────────────────────┐
+  │░░░░░░░░░░░░░░░░░░░░░░░░│ 0
+  │░░░░░░░░░░░░░░░░░░░░░░░░│ 2  ← body top
+  │░░┌──────────────────┐░░│
+  │░░│                  │░░│
+  │░░│      20x20       │░░│
+  │░░│      body        │░░│    ← x=12 center
+  │░░│                  │░░│
+  │░░│                  │░░│
+  │░░└──────────────────┘░░│ 22 ← body bottom
+  │░░░░░░░░░░░░░░░░░░░░░░░░│
+  └────────────────────────┘
+    2                    22
 ```
 
-The 1px padding is tight. Grunt enemies are simple shapes — the padding handles
+The 2px padding is tight. Grunt enemies are simple shapes — the padding handles
 minor animation overshoot (a bounce on idle, a slight lean on walk). Do not plan
 for weapon extensions at this size.
 
@@ -216,38 +218,44 @@ to y=17 = 11px, midpoint would be y=11.5). This low eye placement is what
 creates the chibi "big forehead" look — the forehead area above the eyes is
 larger than the face below.
 
-### 3.2 Small tier proportions (16x16 frame)
+### 3.2 Small tier proportions (24x24 frame)
 
-Grunt enemies at 2-head chibi, ~12px tall, bottom-anchored:
+Grunt enemies at 2-head chibi, ~18px tall, bottom-anchored:
 
 | Guide | Y Position | Zone          |
 | ----- | ---------- | ------------- |
-| HT    | y = 2      | Head top      |
-| EY    | y = 5      | Eye line      |
-| CH    | y = 8      | Chin / neck   |
-| WA    | y = 11     | Waist         |
-| FT    | y = 14     | Feet / ground |
+| HT    | y = 3      | Head top      |
+| EY    | y = 8      | Eye line      |
+| CH    | y = 12     | Chin / neck   |
+| WA    | y = 17     | Waist         |
+| FT    | y = 21     | Feet / ground |
 
 ```
-  0               15
-  ┌────────────────┐
-  │                │ 0
-  │· · · · · · · · │ 2  HT
-  │    ████████    │
-  │· · █·●··●·█ · ·│ 5  EY
-  │    ████████    │
-  │· · ·██████ · · │ 8  CH
-  │     █ ██ █     │
-  │· · ·██████· · ·│ 11 WA
-  │      █  █      │
-  │· · ·██··██· · ·│ 14 FT
-  │                │ 15
-  └────────────────┘
+  0                       23
+  ┌────────────────────────┐
+  │                        │ 0
+  │· · · · · · · · · · · · │ 3  HT
+  │       ██████████       │
+  │       ██████████       │
+  │· · · ·█·●●··●●·█· · · ·│ 8  EY
+  │       ██████████       │
+  │       ██████████       │
+  │· · · · ████████ · · · ·│ 12 CH
+  │        █ ████ █        │
+  │         ██████         │
+  │· · · · ·██████· · · · ·│ 17 WA
+  │          █  █          │
+  │         ██  ██         │
+  │· · · · ███··███ · · · ·│ 21 FT
+  │                        │
+  └────────────────────────┘
 ```
 
-At 16x16, there are very few pixels per zone. The eyes may be just 2
-vertical pixels or a 2x2 block. Personality comes from silhouette shape and
-color rather than facial detail.
+At 24x24, each zone gets a few more pixels than the player's face does —
+the head is ~9px tall, so eyes can be a 2x2 block with 1px of expression
+room. Even so, personality comes primarily from silhouette shape and color
+rather than facial detail. Grunts should read instantly as "threat type"
+at a glance.
 
 ### 3.3 Large tier proportions (48x48 frame)
 
@@ -413,8 +421,8 @@ mannequin back only when you need to double-check proportions.
 templates/
 ├── medium_32x32.aseprite            Blank template with guides
 ├── chibi_mannequin_32x32.aseprite   Full silhouette mannequin
-├── small_16x16.aseprite             Blank template with guides
-├── chibi_mannequin_16x16.aseprite   Grunt silhouette mannequin
+├── small_24x24.aseprite             Blank template with guides
+├── chibi_mannequin_24x24.aseprite   Grunt silhouette mannequin
 ├── large_48x48.aseprite             Blank template with guides
 └── boss_mannequin_48x48.aseprite    Boss silhouette mannequin
 ```

--- a/docs/book/src/art/art-integration.md
+++ b/docs/book/src/art/art-integration.md
@@ -57,17 +57,17 @@ Add an entry to the `sprite_sheets` array:
 {
   "id": "player",
   "path": "assets/sprites/player.png",
-  "frame_w": 16,
-  "frame_h": 16
+  "frame_w": 32,
+  "frame_h": 32
 }
 ```
 
-| Field     | Type   | Description                                       |
-| --------- | ------ | ------------------------------------------------- |
-| `id`      | string | Unique identifier used by `Sprite::sheet_id`      |
-| `path`    | string | Path to the PNG relative to the working directory |
-| `frame_w` | int    | Width of one frame in pixels                      |
-| `frame_h` | int    | Height of one frame in pixels                     |
+| Field     | Type   | Description                                                  |
+| --------- | ------ | ------------------------------------------------------------ |
+| `id`      | string | Unique identifier used by `Sprite::sheet_id`                 |
+| `path`    | string | Path to the PNG, resolved via `paths::asset()` (relative to the executable, never the CWD) |
+| `frame_w` | int    | Width of one frame in pixels                                 |
+| `frame_h` | int    | Height of one frame in pixels                                |
 
 ### Step 3: Optionally add sprite definitions
 
@@ -102,35 +102,50 @@ Defined in `src/ecs/components.hpp`:
 
 ```cpp
 struct Sprite {
-    std::string sheet_id;  // Identifier of the SpriteSheet to draw from.
+    StringId sheet_id;    // Interned identifier of the SpriteSheet to draw from.
     int frame_x = 0;      // Frame column index in the sheet.
     int frame_y = 0;      // Frame row index in the sheet.
-    int width = 16;        // Pixel width of one frame.
-    int height = 16;       // Pixel height of one frame.
-    int layer = 0;         // Render order (higher values draw on top).
-    bool flip_x = false;   // Flip the sprite horizontally when drawing.
+    int width = 32;       // Rendered width in pixels.
+    int height = 32;      // Rendered height in pixels.
+    int layer = 0;        // Render order (higher values draw on top).
+    bool flip_x = false;  // Flip the sprite horizontally when drawing.
+    float offset_x = 0.f; // Horizontal render offset from entity center in pixels.
+    float offset_y = 0.f; // Vertical render offset from entity center in pixels.
 };
 ```
 
 ### Attaching to an entity
 
+Sheet ids are interned through the registry's `StringInterner` context
+variable:
+
 ```cpp
+auto& interner = reg.ctx().get<StringInterner>();
+
 auto entity = reg.create();
 reg.emplace<Transform2D>(entity, 100.f, 50.f);
-reg.emplace<Sprite>(entity, "player", 0, 0, 16, 16, 0, false);
+reg.emplace<Sprite>(entity, interner.intern("player"), 0, 0, 32, 32, 10, false, 0.f, -5.f);
 ```
 
 ### Field reference
 
 | Field      | Meaning                                                         |
 | ---------- | --------------------------------------------------------------- |
-| `sheet_id` | Must match an `id` in config.json's `sprite_sheets`             |
+| `sheet_id` | Interned `StringId` of an `id` in config.json's `sprite_sheets` |
 | `frame_x`  | Column index — which frame within the current animation row     |
 | `frame_y`  | Row index — which animation state                               |
-| `width`    | Frame width in pixels (must match `frame_w` in config)          |
-| `height`   | Frame height in pixels (must match `frame_h` in config)         |
+| `width`    | Rendered width in pixels — normally equal to `frame_w`          |
+| `height`   | Rendered height in pixels — normally equal to `frame_h`         |
 | `layer`    | Drawing order. Higher values render on top of lower values      |
 | `flip_x`   | `true` draws the sprite mirrored horizontally (leftward facing) |
+| `offset_x` | Horizontal draw offset from the entity center                   |
+| `offset_y` | Vertical draw offset — negative shifts the visual up so feet align with the collision center |
+
+When `width`/`height` differ from the sheet's frame size, the engine scales
+the frame at draw time. This is reserved for placeholder art (the current
+16x16 grunt sheet drawn at 24x24); final art is always authored at its
+rendered size and drawn 1:1 — see the
+[Art Specification](art-spec.md).
 
 ### Layer conventions
 
@@ -206,16 +221,19 @@ higher layers draw on top.
 
 ### Centering
 
-Sprites are centered on the entity position. The draw destination is offset by
-half the frame size:
+Sprites are centered on the entity position, then shifted by the render
+offset:
 
 ```cpp
-dest_x = render_x - width / 2;
-dest_y = render_y - height / 2;
+dest_x = render_x + offset_x - width / 2;
+dest_y = render_y + offset_y - height / 2;
 ```
 
-The entity's `Transform2D` position represents the center of the sprite, not the
-top-left corner.
+The entity's `Transform2D` position represents the center of the sprite, not
+the top-left corner. Characters use a negative `offset_y` (the player uses
+-5) so the visual body sits higher while the feet line up with the entity's
+collision center — see the anchoring section of the
+[Aseprite Setup Guide](art-aseprite-guide.md).
 
 ### Horizontal flip
 
@@ -254,12 +272,13 @@ struct Animation {
 };
 ```
 
-### Design intent
+### How it's driven
 
-An animation system (to be implemented) ticks `elapsed` forward each update.
-When `elapsed >= frame_duration`, it advances `current_frame` and writes it back
-to `Sprite::frame_x`. This drives the visual frame displayed by the render
-system.
+`update_animation()` (`src/ecs/systems/animation_system.cpp`) ticks `elapsed`
+forward each update. When `elapsed >= frame_duration`, it advances
+`current_frame` and writes it back to `Sprite::frame_x`. This drives the
+visual frame displayed by the render system. See
+[Sprite Animation](../architecture/sprite-animation.md) for the full design.
 
 ### Field mapping
 
@@ -289,9 +308,11 @@ frame_duration = 1.0 / anim_fps
 
 ---
 
-## 7. Animation State Management (Design)
+## 7. Animation State Management
 
-This section describes the intended design for switching animation states.
+This section describes the pattern for switching animation states. The
+player's state switching lives in `game_scene.cpp` (see
+[Sprite Animation](../architecture/sprite-animation.md)).
 
 ### Switching states
 
@@ -376,25 +397,31 @@ Save the PNG to `assets/sprites/`. Verify it follows the art-spec:
 {
   "id": "goblin",
   "path": "assets/sprites/goblin.png",
-  "frame_w": 16,
-  "frame_h": 16
+  "frame_w": 24,
+  "frame_h": 24
 }
 ```
+
+The goblin is a grunt, so it uses the small tier (24x24 frame, 20x20 body)
+from the [Art Specification](art-spec.md).
 
 ### 3. Create the entity with components
 
 ```cpp
+auto& interner = reg.ctx().get<StringInterner>();
 auto goblin = reg.create();
 
 reg.emplace<Transform2D>(goblin, spawn_x, spawn_y);
 reg.emplace<PreviousTransform>(goblin, spawn_x, spawn_y);
 
-reg.emplace<Sprite>(goblin, "goblin",
+reg.emplace<Sprite>(goblin, interner.intern("goblin"),
     0,      // frame_x: first frame
     0,      // frame_y: idle row
-    16, 16, // width, height
+    24, 24, // width, height (match frame_w/frame_h — drawn 1:1)
     30,     // layer: enemy layer
-    false   // flip_x
+    false,  // flip_x
+    0.f,    // offset_x
+    -3.f    // offset_y: feet alignment (bottom-center anchor)
 );
 
 reg.emplace<Animation>(goblin,

--- a/docs/book/src/art/art-spec.md
+++ b/docs/book/src/art/art-spec.md
@@ -12,7 +12,8 @@ sprite, tile, and UI element is authored at this resolution.
 
 - A 24x24 character body (in a 32x32 frame) occupies ~5% of screen width —
   between Blazing Beaks and Nuclear Throne in proportion.
-- A 16x16 grunt enemy occupies ~3.3% of screen width (30 tiles across).
+- A 20x20 grunt enemy body (in a 24x24 frame) occupies ~4.2% of screen width —
+  clearly smaller than the player, but still readable at 480x270.
 - All art is authored at **1:1** — one pixel in Aseprite equals one game pixel.
   Never pre-scale.
 
@@ -52,7 +53,7 @@ placement.
 | Entity            | Frame Size | Body Size | Notes                                    |
 | ----------------- | ---------- | --------- | ---------------------------------------- |
 | Player character  | 32x32      | 24x24     | 4px padding for weapons and dash effects |
-| Standard enemies  | 16x16      | 14x14     | 1px padding, simple shapes               |
+| Standard enemies  | 24x24      | 20x20     | 2px padding, simple shapes               |
 | Mid-tier enemies  | 32x32      | 24x24     | Same tier as player                      |
 | Bosses            | 48x48      | 36x36     | 6px padding for dramatic attacks         |
 | Mega-bosses       | 64x64      | 48x48     | 8px padding, screen-dominating           |
@@ -90,6 +91,20 @@ All frames in a single sheet must be the same size — the engine uses a uniform
 grid to address frames. The body size is a guideline for idle/walk poses;
 action frames may extend into the padding zone.
 
+The body size is an **art** guideline only. Gameplay hitboxes are tuned
+separately in code (`wave_system.cpp`, `game_scene.cpp`) and are generally
+smaller than the body so combat feels fair.
+
+### Note on current placeholder art
+
+The grunt sheet currently in the repo (`assets/sprites/enemies.png`) predates
+this spec revision: it is authored at 16x16 and the engine temporarily upscales
+it to 24x24 at draw time (a 1.5x non-integer scale). This is a stopgap for
+placeholder art only — **new grunt art must be authored at 24x24** per the
+table above, at which point the sheet's `frame_w`/`frame_h` in
+`assets/data/config.json` changes from 16 to 24 and the engine draws it 1:1
+with no scaling.
+
 ---
 
 ## 4. Animation Frame Counts and Timing
@@ -115,7 +130,12 @@ visuals. Idle and walk frames stay within the 24x24 body zone.
 Key principle: fewer frames with longer holds looks better in pixel art than
 many frames played fast. Each frame should be a distinct, readable pose.
 
-### Standard Enemies (16x16)
+> **Placeholder status:** the current `player.png` implements only the idle
+> and walk rows; melee and dash temporarily reuse the walk row at faster
+> timings in `game_scene.cpp`. The table above is the target for final art —
+> when the attack/dodge/hurt/death rows land, the code switches to them.
+
+### Standard Enemies (24x24 frame, 20x20 body)
 
 | State       | Frames | Anim FPS | Loop? | Notes                          |
 | ----------- | ------ | -------- | ----- | ------------------------------ |
@@ -125,7 +145,7 @@ many frames played fast. Each frame should be a distinct, readable pose.
 | Hurt        | 2      | 8        | No    | Brief flinch                   |
 | Death       | 4      | 8        | No    | Satisfying pop / collapse      |
 
-### Large Enemies / Mini-bosses (24x24)
+### Mid-tier Enemies / Mini-bosses (32x32 frame, 24x24 body)
 
 Same states as standard enemies. The extra pixel real estate allows 1–2 more
 frames per state. Attack telegraph must be very readable — use a bright wind-up
@@ -170,7 +190,7 @@ Boss attack telegraphs should use the 6–8px padding zone for wind-up frames
   24x24 body size. Use the frame padding for overshoot.
 - **Overlapping action.** Hair, capes, and tails lag 1–2 frames behind the body.
 - **Silhouette test.** Every character must be recognizable as a solid black
-  fill at its body size (24x24 for player, 14x14 for grunts).
+  fill at its body size (24x24 for player, 20x20 for grunts).
 
 ---
 
@@ -273,7 +293,7 @@ Row 5: Death   [5 frames] █████░
 | Virtual resolution   | 480x270                           |
 | Primary scale target | 4x (1080p)                        |
 | Player frame / body  | 32x32 frame, 24x24 body           |
-| Grunt enemy size     | 16x16 frame, 14x14 body           |
+| Grunt enemy size     | 24x24 frame, 20x20 body           |
 | Mid enemy size       | 32x32 frame, 24x24 body           |
 | Boss size            | 48x48 frame, 36x36 body           |
 | Mega-boss size       | 64x64 frame, 48x48 body           |
@@ -293,7 +313,7 @@ Row 5: Death   [5 frames] █████░
 
 Run through this list before every handoff:
 
-- [ ] Frame size matches the spec table (32x32, 16x16, 48x48, etc.)
+- [ ] Frame size matches the spec table (32x32, 24x24, 48x48, etc.)
 - [ ] Idle/walk art stays within the body zone (see Aseprite Setup Guide)
 - [ ] Action frames use padding zone appropriately — no art clipped at frame edge
 - [ ] No padding between frames in the exported sheet


### PR DESCRIPTION
The engine has rendered grunts at 24x24 on screen since the tiered
sprite-size upgrade, but the art docs still specified 16x16 grunts.
Make 24x24 frame / 20x20 body the authored grunt size so future art
is drawn 1:1 with no runtime scaling, and note that the current
16x16 sheet is a temporarily-upscaled placeholder.

- art-spec: new grunt tier in size tables, proportions, silhouette
  test, quick reference, and delivery checklist; note placeholder
  status of the current grunt and player sheets
- aseprite guide: small tier retargeted to 24x24 (guides, chibi
  proportions, template filenames)
- art-integration: sync Sprite component listing and examples with
  the current code (StringId sheet ids, 32x32 defaults, render
  offsets, implemented animation system, executable-relative paths)